### PR TITLE
switched debug tag from print_r to var_dump

### DIFF
--- a/lib/Twig/Extensions/Node/Debug.php
+++ b/lib/Twig/Extensions/Node/Debug.php
@@ -51,11 +51,11 @@ class Twig_Extensions_Node_Debug extends Twig_Node
                 ->write("}\n")
                 ->outdent()
                 ->write("}\n")
-                ->write("print_r(\$vars);\n")
+                ->write("var_dump(\$vars);\n")
             ;
         } else {
             $compiler
-                ->write("print_r(")
+                ->write("var_dump(")
                 ->subcompile($this->getNode('expr'))
                 ->raw(");\n")
             ;

--- a/test/Twig/Tests/Node/DebugTest.php
+++ b/test/Twig/Tests/Node/DebugTest.php
@@ -47,7 +47,7 @@ if (\$this->env->isDebug()) {
             \$vars[\$key] = \$value;
         }
     }
-    print_r(\$vars);
+    var_dump(\$vars);
 }
 EOF
         );
@@ -57,7 +57,7 @@ EOF
 
         $tests[] = array($node, <<<EOF
 if (\$this->env->isDebug()) {
-    print_r((isset(\$context['foo']) ? \$context['foo'] : null));
+    var_dump((isset(\$context['foo']) ? \$context['foo'] : null));
 }
 EOF
         );


### PR DESCRIPTION
This is a better function for debugging. It's also formatted pretty in HTML if your settings are configured correctly.
