### PR TITLE
PDO template loader

### DIFF
--- a/lib/Twig/Extensions/Loader/Pdo.php
+++ b/lib/Twig/Extensions/Loader/Pdo.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2010 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Twig_Extensions_Loader_Pdo implements Twig_LoaderInterface
+{
+    protected $db;
+    protected $options;
+    protected $cache = array();
+    protected $cacheLoaded = false;
+
+    /**
+     * Constructor.
+     *
+     * @param  PDO   $db      A PDO instance
+     * @param  array $options An associative array of DB options
+     *
+     * @throws Twig_Error_Loader When "db_table" option is not provided
+     */
+    public function __construct(PDO $db, array $options)
+    {
+        if (!array_key_exists('db_table', $options)) {
+            throw new Twig_Error_Loader('You must provide the "db_table" option for a Pdo loader.');
+        }
+
+        $this->db = $db;
+        $this->options = array_merge(array(
+            'db_name_col' => 'tpl_name',
+            'db_data_col' => 'tpl_data',
+            'db_time_col' => 'tpl_time',
+        ), $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSource($name)
+    {
+        $template = $this->findTemplate($name);
+
+        return $template['data'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCacheKey($name)
+    {
+        $template = $this->findTemplate($name);
+
+        return $template['data'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isFresh($name, $time)
+    {
+        $template = $this->findTemplate($name);
+
+        return $template['time'] < $time;
+    }
+
+    protected function findTemplate($name)
+    {
+        $this->loadCache();
+
+        if (isset($this->cache[$name])) {
+            return $this->cache[$name];
+        }
+
+        throw new Twig_Error_Loader(sprintf('Template "%s" is not defined.', $name));
+    }
+
+    protected function loadCache()
+    {
+        if (true === $this->cacheLoaded) {
+            return;
+        }
+
+        // get table/column
+        $dbTable  = $this->options['db_table'];
+        $dbNameCol = $this->options['db_name_col'];
+        $dbDataCol = $this->options['db_data_col'];
+        $dbTimeCol = $this->options['db_time_col'];
+
+        $sql = 'SELECT '.$dbNameCol.', '.$dbDataCol.', '.$dbTimeCol.' FROM '.$dbTable;
+
+        try {
+            $stmt = $this->db->query($sql);
+            foreach ($stmt->fetchAll(PDO::FETCH_NUM) as $template) {
+                $this->cache[$template[0]] = array(
+                    'data' => $template[1],
+                    'time' => $template[2],
+                );
+            }
+
+            $this->cacheLoaded = true;
+        } catch (PDOException $e) {
+            throw new Twig_Error_Loader(sprintf('PDOException was thrown when trying to load templates: %s', $e->getMessage()));
+        }
+    }
+}


### PR DESCRIPTION
A PDO template loader for Twig.

Following default options are available:

<table>
  <thead>
    <tr>
      <th>Option</th>
      <th>Default</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>db_table</td>
      <td>null</td>
    </tr>
    <tr>
      <td>db_name_col</td>
      <td>tpl_name</td>
    </tr>
    <tr>
      <td>db_data_col</td>
      <td>tpl_data</td>
    </tr>
    <tr>
      <td>db_time_col</td>
      <td>tpl_time</td>
    </tr>
  <tbody>
</table>


Example schema:

``` sql
CREATE TABLE IF NOT EXISTS templates (
    tpl_name TEXT,
    tpl_data TEXT,
    tpl_time INTEGER;
    PRIMARY KEY (tpl_name)
);
```

Example usage (similar to [PdoSessionStorage](1)):

``` php
<?php

require_once '/path/to/lib/Twig/Autoloader.php';
Twig_Autoloader::register();

$db = new PDO('sqlite://pathto/to/sqlite.db');

$loader = new Twig_Extensions_Loader_Pdo($db, array(
    'db_table' => 'templates'
));
$twig = new Twig_Environment($loader, array(
  'cache' => '/path/to/compilation_cache',
));
```
