### PR TITLE
Fix autoload path for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         "twig/twig": "1.*"
     },
     "autoload": {
-        "psr-0": { "Twig_Extensions_": "lib/Twig/Extensions" }
+        "psr-0": { "Twig_Extensions_": "lib/" }
     }
 }


### PR DESCRIPTION
The autoload path makes composer autoload to look for extensions in path like :

/vendor/twig/extensions/lib/Twig/Extensions/Twig/Extensions/Extension/I18n.php

It should be : 

/vendor/twig/extensions/lib/Twig/Extensions/Extension/I18n.php

This patch should fix the problem
