### PR TITLE
Wordwrap : wrong behavior when preserving

### DIFF
--- a/lib/Twig/Extensions/Extension/Text.php
+++ b/lib/Twig/Extensions/Extension/Text.php
@@ -69,22 +69,26 @@ if (function_exists('mb_get_info')) {
     {
         $sentences = array();
 
-        $previous = mb_regex_encoding();
-        mb_regex_encoding($env->getCharset());
-
-        $pieces = mb_split($separator, $value);
-        mb_regex_encoding($previous);
-
-        foreach ($pieces as $piece) {
-            while(!$preserve && mb_strlen($piece, $env->getCharset()) > $length) {
-                $sentences[] = mb_substr($piece, 0, $length, $env->getCharset());
-                $piece = mb_substr($piece, $length, 2048, $env->getCharset());
-            }
-
-            $sentences[] = $piece;
+        if(!$preserve) {
+            $previous = mb_regex_encoding();
+        	mb_regex_encoding($env->getCharset());
+        	
+        	$pieces = mb_split($separator, $value);
+        	mb_regex_encoding($previous);
+        	
+        	foreach ($pieces as $piece) {
+        		while(mb_strlen($piece, $env->getCharset()) > $length) {
+        			$sentences[] = mb_substr($piece, 0, $length, $env->getCharset());
+        			$piece = mb_substr($piece, $length, 2048, $env->getCharset());
+        		}
+        	
+        		$sentences[] = $piece;
+        	}
+        	
+        	return implode($separator, $sentences);        	
+        } else {
+        	return wordwrap($value, $length, $separator, true);
         }
-
-        return implode($separator, $sentences);
     }
 } else {
     function twig_truncate_filter(Twig_Environment $env, $value, $length = 30, $preserve = false, $separator = '...')


### PR DESCRIPTION
If "mb_get_info" exist, there is a special "twig_wordwrap_filter" function not using the php default php wordwrap function. I don't know why it has been done this way, i guess using multibyte string is faster or better regarding encoding support than with the default php wordwrap function.

Anyway, the behavior of this custom function is wrong when $preserve = true, the string is simply the same before and after the filter is applied to it. Also, correct me if i'm wrong but, mb_split use $separator as its separator, the separator used in wordwrap is only supposed to be what is inserted at the end of each new string segments, not what is used to split.

My pull request is trivial and i imagine it won't be the kind of fix you want for this, but i at least wanted to point out this problem.
