### PR TITLE
Use the timezone used by php date functions for the formatter.

### DIFF
--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -54,7 +54,8 @@ function twig_localized_date_filter($date, $dateFormat = 'medium', $timeFormat =
     $formatter = IntlDateFormatter::create(
         $locale !== null ? $locale : Locale::getDefault(),
         $formatValues[$dateFormat],
-        $formatValues[$timeFormat]
+        $formatValues[$timeFormat],
+        date_default_timezone_get()
     );
 
     if (!$date instanceof DateTime) {


### PR DESCRIPTION
See http://stackoverflow.com/questions/9499830/php-intldateformatter-format-returns-wrong-date
Without this the formatter may return the time in GMT/UTC, depending on the OS setting which might be out of control for some users ...
