### PR TITLE
Date filter will use the default timezone defined in php.ini 

### DIFF
--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -54,7 +54,8 @@ function twig_localized_date_filter($date, $dateFormat = 'medium', $timeFormat =
     $formatter = IntlDateFormatter::create(
         $locale !== null ? $locale : Locale::getDefault(),
         $formatValues[$dateFormat],
-        $formatValues[$timeFormat]
+        $formatValues[$timeFormat],
+        date_default_timezone_get()
     );
 
     if (!$date instanceof DateTime) {


### PR DESCRIPTION
Currently, the date filter only uses the system timezone (as it does not give any timezone to [`IntlDateFormatter::create`](http://fr2.php.net/manual/en/intldateformatter.create.php)).

This can lead to very undesired behaviour.
For example, in my case,
I have this date: `2012-08-27`
and when I pass it to the `localizeddate` filter it gives me: `26 août 2012` but only on my remote server!
Locally, it gives me `27 août 2012`.

Even if the date.timezone is the same on both server: `Europe/Paris`.

So, I hope this little fix will help others!
