### PR TITLE
localizeddate filter : using of timezone from "PHP ini setting"

### DIFF
--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -54,7 +54,8 @@ function twig_localized_date_filter($date, $dateFormat = 'medium', $timeFormat =
     $formatter = IntlDateFormatter::create(
         $locale !== null ? $locale : Locale::getDefault(),
         $formatValues[$dateFormat],
-        $formatValues[$timeFormat]
+        $formatValues[$timeFormat],
+        date_default_timezone_get()
     );
 
     if (!$date instanceof DateTime) {


### PR DESCRIPTION
localizeddate filter : now IntlDateFormatter uses timezone from "PHP ini setting", and not from "TZ environment variable" (default behavior).

See the comment here : http://www.php.net/manual/fr/intldateformatter.create.php#108109

Thanks and regards.
