### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "twig/twig": "1.*"
     },
     "autoload": {
-        "psr-0": { "Twig_Extensions_": "lib/" }
+        "psr-0": { "Twig_Extensions_Extension_": "lib/" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
The autoload path that Twig extensions uses conflicts with Slim/Extras.
This change fixes that.
