### PR TITLE
Gettext extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "require": {
         "twig/twig": "1.*"
     },
+    "suggest": {
+        "kunststube/potools": "Provides compatible classes for creating .pot files from extracted gettext strings"
+    },
     "autoload": {
         "psr-0": { "Twig_Extensions_": "lib/" }
     },

--- a/doc/gettext.rst
+++ b/doc/gettext.rst
@@ -117,9 +117,10 @@ To generate ``.pot`` files from the returned array, you need a tool that can mer
     Twig_Autoloader::register();
     Twig_Extensions_Autoloader::register();
 
-    $poFactory = new Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter_Factory;
-    $extractor = new Twig_Extensions_Extension_Gettext_Extractor($poFactory);
-    $catalog   = new Kunststube\POTools\Catalog;
+    $poFactory  = new Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter_Factory;
+    #extensions = array(new Twig_Extensions_Extension_Gettext);
+    $extractor  = new Twig_Extensions_Extension_Gettext_Extractor($poFactory, $extensions);
+    $catalog    = new Kunststube\POTools\Catalog;
 
     $templatesDir = 'templates';
     foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($templatesDir), RecursiveIteratorIterator::LEAVES_ONLY) as $file)
@@ -136,7 +137,9 @@ To generate ``.pot`` files from the returned array, you need a tool that can mer
     $catalog->writeToDirectory('locale/en');
 
 
-You can write your own tools if you have different needs. All you need is a class that implements ``Twig_Extensions_Extension_Gettext_POString_Interface``. This is simply a container object that represents one translatable string with all its different possible attributes like domain, context etc. You then pass a factory that implements ``Twig_Extensions_Extension_Gettext_POString_Factory_Interface`` to the extractor class, which allows the extractor to generate one such container object for each extracted string and return an array of such objects. The catalog in the above example has the job of merging and grouping these and writing them into files with the correct format.
+You can write your own toolchain to deal with the extracted strings if you have different needs. All you need is a class that implements ``Twig_Extensions_Extension_Gettext_POString_Interface``. This is simply a container object that represents one translatable string with all its different possible attributes like domain, context etc. You then pass a factory that implements ``Twig_Extensions_Extension_Gettext_POString_Factory_Interface`` to the extractor class, which allows the extractor to generate one such container object for each extracted string and return an array of such objects. The catalog in the above example has the job of merging and grouping these and writing them into POT files with the correct format.
+
+You should also pass an array of the same extensions you load into the regular Twig environment to the Extractor class as the second constructor argument, which should typically include the `Twig_Extensions_Extension_Gettext`.
 
 
 Comments

--- a/doc/gettext.rst
+++ b/doc/gettext.rst
@@ -118,7 +118,7 @@ To generate ``.pot`` files from the returned array, you need a tool that can mer
     Twig_Extensions_Autoloader::register();
 
     $poFactory  = new Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter_Factory;
-    #extensions = array(new Twig_Extensions_Extension_Gettext);
+    $extensions = array(new Twig_Extensions_Extension_Gettext);
     $extractor  = new Twig_Extensions_Extension_Gettext_Extractor($poFactory, $extensions);
     $catalog    = new Kunststube\POTools\Catalog;
 

--- a/doc/gettext.rst
+++ b/doc/gettext.rst
@@ -164,6 +164,24 @@ If there is one or more lines of whitespace between the comment and the ``gettex
     *Any* comment block on the preceeding line will be extracted. Take care that it's not a commented-out block of code.
 
 
+Format filters
+^^^^^^^^^^^^^^
+
+The ``Extractor`` attempts to detect when a string is in ``sprintf`` format, which means when it's chained to a Twig ``format`` filter. In this case it sets the ``php-format`` flag on the extracted string, which tools further down in the workflow (can) use for checking the correctness of translated strings. For example:
+
+.. code-block:: jinja
+
+    <p>{{ 'The %s contains %d monkeys'|gettext|format(thing, num) }}</p>
+    
+Resulting ``.po`` file entry:
+
+.. code-block:: text
+
+    #, php-format
+    msgid "The %s contains %d monkeys"
+    msgstr ""
+
+
 .. _api-docs:
 
 API

--- a/doc/gettext.rst
+++ b/doc/gettext.rst
@@ -53,14 +53,14 @@ Wrap any translatable string in your templates into one of the appropriate gette
     <h1>{{ _('Hello World!') }}</h1>
     <h1>{{ 'Hello World!'|gettext }}</h1>
     
-    <p>{{ _n('One day without accident.', '%d days without accident.', n)|sprintf(n) }}</p>
+    <p>{{ _n('One day without accident.', '%d days without accident.', n)|format(n) }}</p>
     
     {#
        The %s is an noun, the %d a number. If you need to
        switch the order of the placeholders for translation,
        use %1$s and %2$d instead.
     #}
-    <p>{{ 'The %s contains %d monkeys'|gettext|sprintf(thing, num) }}</p>
+    <p>{{ 'The %s contains %d monkeys'|gettext|format(thing, num) }}</p>
     
     <input type="submit" value="{{ 'Update'|_p('verb') }}">
     
@@ -105,28 +105,6 @@ The translation files are organized in a directory structure like this:
         ...
 
 ``en_US`` is the *locale*, which is selected using the ``setlocale`` function. ``LC_MESSAGES``, ``LC_MONETARY`` are *categories*, each category can be switched to use a different locale; for instance you can localize text to English while formatting numbers and times in French format, if your users so desire. The names of the ``.mo`` files are the *domain*, they help you organize your strings into groups. Inside the ``.mo`` files a string may be marked with a *context*. Contexts help you distiguish between two identical strings which may translate differently, for example ``_p('verb', 'Update')`` and ``_p('noun', 'Update')``. Try to use these distictions while writing code, it makes the translation job easier later on.
-
-The Gettext extension also defines the ``sprintf`` filter to replicate the typical use of `sprintf`_ in combination with gettext:
-
-.. code-block:: php
-
-    // regular PHP
-    <?php printf(_('The %s contains %d monkeys'), $thing, $num); ?>
-
-.. code-block:: jinja
-
-    {# Twig gettext equivalent #}
-    {{ 'The %s contains %d monkeys'|gettext|sprintf(thing, num) }}
-
-.. code-block:: php
-
-    // regular PHP
-    <?php printf(ngettext('The %s contains one monkey', 'The %s contains %d monkeys', $num), $thing, $num); ?>
-    
-.. code-block:: jinja
-    
-    {# Twig gettext equivalent #}
-    {{ _n('The %s contains one monkey', 'The %s contains %d monkeys', num)|sprintf(thing, num) }}
 
 
 String extraction
@@ -372,7 +350,6 @@ I recommend again that you read the `GNU gettext documentation`_ to learn more a
 
 .. _`gettext`:                   http://www.php.net/gettext
 .. _`documentation`:             http://php.net/manual/en/function.gettext.php
-.. _`sprintf`:                   http://php.net/sprintf
 .. _`GNU gettext documentation`: http://www.gnu.org/software/gettext/manual/gettext.html
 .. _`msgmerge`:                  http://www.gnu.org/software/gettext/manual/gettext.html#msgmerge-Invocation
 .. _`msgfmt`:                    http://www.gnu.org/software/gettext/manual/gettext.html#msgfmt-Invocation

--- a/doc/gettext.rst
+++ b/doc/gettext.rst
@@ -1,0 +1,454 @@
+The Gettext Extension
+=====================
+
+The Gettext extension adds complete `gettext`_ support to Twig. It defines a whole host of functions that can be used in Twig templates. It also adds an ``Extractor`` class, which can parse Twig templates and extract all strings marked for localization. The gettext support includes:
+
+* categories
+* domains
+* context
+* plurals
+* extractable comments
+* convenience wrapper for string formatting
+
+Configuration
+-------------
+
+You need to register this extension before using any of the gettext functions::
+
+    $twig->addExtension(new Twig_Extensions_Extension_Gettext);
+
+Note that you must configure the PHP ``gettext`` extension before rendering any
+internationalized template. Here is a simple configuration example from the
+PHP `documentation`_::
+
+    // Set language to French
+    putenv('LC_ALL=fr_FR');
+    setlocale(LC_ALL, 'fr_FR');
+
+    // Specify the location of the translation tables
+    bindtextdomain('myAppPhp', 'includes/locale');
+    bind_textdomain_codeset('myAppPhp', 'UTF-8');
+
+    // Choose domain
+    textdomain('myAppPhp');
+
+.. caution::
+
+    The Gettext extension only works if the PHP `gettext`_ extension is
+    enabled.
+    
+The ``Twig_Extensions_Extension_Gettext`` class accepts one constructor argument: ``$useShortnames``. By default it is set to ``true``, which means every gettext function is aliased to a shortname. If this conflicts with another extension, set it to false::
+
+    $twig->addExtension(new Twig_Extensions_Extension_Gettext(false));
+
+The examples below assume shortnames are on, see :ref:`API documentation <api-docs>` for alternative names.
+
+    
+Usage
+-----
+
+Wrap any translatable strings in your templates into one of the appropriate gettext functions:
+
+.. code-block:: jinja
+
+    <h1>{{ _('Hello World!') }}</h1>
+    <p>{{ _nf('It has been one day without apocalypse.', 'It has been %d days without apocalypse.', n, n) }}</p>
+    
+    {#
+       The %s is an noun, the %d a number. If you need to
+       switch the order of the placeholders for translation,
+       use %1$s and %2$d instead.
+    #}
+    <p>{{ _f('The %s contains %d monkeys', thing, num) }}</p>
+    
+    <input type="submit" value="{{ _p('verb', 'Update') }}">
+    
+    {% if someError %}
+        <p>{{ _d('errors', 'Some error occurred!') }}</p>
+    {% endif %}
+    
+All gettext functions either start with an underscore (short aliases) or end in ``gettext`` (full name). There are many variations of the basic ``_()``/``gettext()`` function, each with an array of letters tagged on. The letters are shorthand for various attributes that can be modified about the translatable string:
+
+* ``n``: pluralization
+* ``d``: override default domain
+* ``c``: override ``LC_MESSAGES`` category
+* ``p``: put the string in a context
+* ``f``: convenience wrapper for `sprintf`_
+
+The full `GNU gettext documentation`_ details the usage of these different aspects and I highly recommend you read it. A short summary follows.
+
+The translation files are organized in a directory structure like this:
+
+.. code-block:: text
+
+    locale/
+        en_US/
+            LC_MESSAGES/
+                default.mo
+                errors.mo
+                ...
+            LC_MONETARY/
+                default.mo
+                ...
+            ...
+        ...
+
+``en_US`` is the *locale*, which is selected using the ``setlocale`` function. ``LC_MESSAGES``, ``LC_MONETARY`` are *categories*, each category can be switched to use a different locale; for instance you can localize text to English while formatting numbers and times in French format, if your users so desire. The names of the ``.mo`` files are the *domain*, they help you organize your strings into groups. Inside the ``.mo`` files a string may be marked with a *context*. Contexts help you distiguish between two identical strings which may translate differently, for example ``_p('verb', 'Update')`` and ``_p('noun', 'Update')``. Try to use these distictions while writing code, it makes the translation job easier later on.
+
+The ``f`` functions are a convenience wrapper added by the Twig ``gettext`` extension. They allow you to pass an arbitrary number of parameters which will be used as parameters to `sprintf`_ after localizing the string. For example:
+
+.. code-block:: php
+
+    // regular PHP
+    <?php printf(_('The %s contains %d monkeys'), $thing, $num); ?>
+
+.. code-block:: jinja
+
+    {# Twig gettext equivalent #}
+    {{ _f('The %s contains %d monkeys', thing, num) }}
+
+.. code-block:: php
+
+    // regular PHP
+    <?php printf(ngettext('The %s contains one monkey', 'The %s contains %d monkeys', $num), $thing, $num); ?>
+    
+.. code-block:: jinja
+    
+    {# Twig gettext equivalent #}
+    {{ _nf('The %s contains one monkey', 'The %s contains %d monkeys', num, thing, num) }}
+
+
+String extraction
+-----------------
+
+Automated string extraction is an important step in working with ``gettext``. You should never manually edit ``.po`` files or add entries to them, this needs to happen automatically from the prepared source code or you'll have a really hard time coordinating updated source strings with translated files. The Twig ``gettext`` extension comes with a class that parses the Twig template files and returns an array of extracted strings: ``Twig_Extensions_Extension_Gettext_Extractor``.
+
+To generate ``.pot`` files from the returned array, you need a tool that can merge all extracted strings into a catalog and write this catalog into the various ``.pot`` files. The Twig ``gettext`` extension comes with an adapter to the `Kunststube\\POTools`_ library which handles this job. Assuming you have installed this library and it is autoloading, an extraction script can look like this::
+
+    Twig_Autoloader::register();
+    Twig_Extensions_Autoloader::register();
+
+    $poFactory = new Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter_Factory;
+    $extractor = new Twig_Extensions_Extension_Gettext_Extractor($poFactory);
+    $catalog   = new Kunststube\POTools\Catalog;
+
+    $templatesDir = 'templates';
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($templatesDir), RecursiveIteratorIterator::LEAVES_ONLY) as $file)
+
+        if ($file->isFile()) {
+            $strings = $extractor->extractFile($file);
+            foreach ($strings as $string) {
+                $catalog->add($string);
+            }
+        }
+
+    }
+    
+    $catalog->writeToDirectory('locale/en');
+
+
+You can write your own tools if you have different needs. All you need is a class that implements ``Twig_Extensions_Extension_Gettext_POString_Interface``. This is simply a container object that represents one translatable string with all its different possible attributes like domain, context etc. You then pass a factory that implements ``Twig_Extensions_Extension_Gettext_POString_Factory_Interface`` to the extractor class, which allows the extractor to generate one such container object for each extracted string and return an array of such objects. The catalog in the above example has the job of merging and grouping these and writing them into files with the correct format.
+
+
+Comments
+^^^^^^^^
+
+The ``Twig_Extensions_Extension_Gettext_Extractor`` extracts Twig comments on the line(s) immediately preceeding the line with the ``gettext`` function. This allows the programmer to annotate translatable strings with instructions for the translator. It is an important tool for making the translation process smoother and producing high quality translations. For example:
+
+.. code-block:: jinja
+
+    {# Please do not translate "Foo", it is our product name and the whole sentence is a word play. #}
+    <p>{{ _("Get Foobar'd today!") }}</p>
+    
+The extracted ``.po`` file will contain:
+
+.. code-block:: text
+
+    #. Please do not translate "Foo", it is our product name and the whole sentence is a word play.
+    msgid "Get Foobar'd today!"
+    msgstr ""
+
+If there is one or more lines of whitespace between the comment and the ``gettext`` function, the comment won't be extracted.
+
+.. caution::
+
+    *Any* comment block on the preceeding line will be extracted. Take care that it's not a commented-out block of code.
+
+
+.. _api-docs:
+
+API
+---
+
+* ``gettext``, ``_``
+
+  Basic translation in default domain and ``LC_MESSAGES`` category.
+
+  .. code-block:: jinja
+  
+      {{ gettext('String') }}
+      {{ _('String') }}
+
+* ``fgettext``, ``_f``
+
+  Translation in default domain and ``LC_MESSAGES`` category with string formatting.
+
+  .. code-block:: jinja
+  
+      {{ fgettext('String', arg, ..) }}
+      {{ _f('String', arg, ..) }}
+
+* ``pgettext``, ``_p``
+
+  Translation in default domain and ``LC_MESSAGES`` category with context.
+
+  .. code-block:: jinja
+  
+      {{ pgettext('context', 'String') }}
+      {{ _p('context', 'String') }}
+
+* ``pfgettext``, ``_pf``
+
+  Translation in default domain and ``LC_MESSAGES`` category with context and string formatting.
+
+  .. code-block:: jinja
+  
+      {{ pfgettext('context', 'String', arg, ..) }}
+      {{ _pf('context', 'String', arg, ..) }}
+
+* ``ngettext``, ``_n``
+
+  Pluralized translation in default domain and ``LC_MESSAGES`` category.
+
+  .. code-block:: jinja
+  
+      {{ ngettext('Singular', 'Plural', num) }}
+      {{ _n('Singular', 'Plural', num) }}
+
+* ``nfgettext``, ``_nf``
+
+  Pluralized translation in default domain and ``LC_MESSAGES`` category with string formatting.
+
+  .. code-block:: jinja
+  
+      {{ nfgettext('Singular', 'Plural', num, arg, ..) }}
+      {{ _nf('Singular', 'Plural', num, arg, ..) }}
+
+* ``npgettext``, ``_np``
+
+  Pluralized translation in default domain and ``LC_MESSAGES`` category with context.
+
+  .. code-block:: jinja
+  
+      {{ npgettext('context', 'Singular', 'Plural', num) }}
+      {{ _np('context', 'Singular', 'Plural', num) }}
+
+* ``npfgettext``, ``_npf``
+
+  Pluralized translation in default domain and ``LC_MESSAGES`` category with context and string formatting.
+
+  .. code-block:: jinja
+  
+      {{ npfgettext('context', 'Singular', 'Plural', num, arg, ..) }}
+      {{ _npf('context', 'Singular', 'Plural', num, arg, ..) }}
+
+* ``dgettext``, ``_d``
+
+  Translation in ``LC_MESSAGES`` category and specified domain.
+
+  .. code-block:: jinja
+  
+      {{ dgettext('domain', 'String') }}
+      {{ _d('domain', 'String') }}
+
+* ``dfgettext``, ``_df``
+
+  Translation in ``LC_MESSAGES`` category and specified domain with string formatting.
+
+  .. code-block:: jinja
+  
+      {{ dfgettext('domain', 'String', arg, ..) }}
+      {{ _df('domain', 'String', arg, ..) }}
+
+* ``dpgettext``, ``_dp``
+
+  Translation in ``LC_MESSAGES`` category and specified domain with context.
+
+  .. code-block:: jinja
+  
+      {{ dpgettext('context', 'domain', 'String') }}
+      {{ _dp('context', 'domain', 'String') }}
+
+* ``dpfgettext``, ``_dpf``
+
+  Translation in ``LC_MESSAGES`` category and specified domain with context and string formatting.
+
+  .. code-block:: jinja
+  
+      {{ dpfgettext('context', 'domain', 'String', arg, ..) }}
+      {{ _dpf('context', 'domain', 'String', arg, ..) }}
+
+* ``dngettext``, ``_dn``
+
+  Pluralized translation in ``LC_MESSAGES`` category and specified domain.
+
+  .. code-block:: jinja
+  
+      {{ dngettext('domain', 'Singular', 'Plural', num) }}
+      {{ _dn('domain', 'Singular', 'Plural', num) }}
+
+
+* ``dnfgettext``, ``_dnf``
+
+  Pluralized translation in ``LC_MESSAGES`` category and specified domain with string formatting.
+
+  .. code-block:: jinja
+  
+      {{ dnfgettext('domain', 'Singular', 'Plural', num, arg, ..) }}
+      {{ _dnf('domain', 'Singular', 'Plural', num, arg, ..) }}
+
+* ``dnpgettext``, ``_dnp``
+
+  Pluralized translation in ``LC_MESSAGES`` category and specified domain with context.
+
+  .. code-block:: jinja
+  
+      {{ dnpgettext('context, 'domain', 'Singular', 'Plural', num) }}
+      {{ _dnp('context', 'domain', 'Singular', 'Plural', num) }}
+
+* ``dnpfgettext``, ``_dnpf``
+
+  Pluralized translation in ``LC_MESSAGES`` category and specified domain with context and string formatting.
+
+  .. code-block:: jinja
+  
+      {{ dnpfgettext('context, 'domain', 'Singular', 'Plural', num, arg, ..) }}
+      {{ _dnpf('context', 'domain', 'Singular', 'Plural', num, arg, ..) }}
+
+* ``dcgettext``, ``_dc``
+
+  Translation in specified domain and category.
+
+  .. code-block:: jinja
+  
+      {{ dcgettext('domain', 'String', 'category') }}
+      {{ _dc('domain', 'String', 'category') }}
+
+* ``dcfgettext``, ``_dcf``
+
+  Translation in specified domain and category with string formatting.
+
+  .. code-block:: jinja
+  
+      {{ dcfgettext('domain', 'String', 'category', arg, ..) }}
+      {{ _dcf('domain', 'String', 'category', arg, ..) }}
+
+* ``dcpgettext``, ``_dcp``
+
+  Translation in specified domain and category with context.
+
+  .. code-block:: jinja
+  
+      {{ dcpgettext('context', 'domain', 'String', 'category') }}
+      {{ _dcp('context', 'domain', 'String', 'category') }}
+
+
+* ``dcpfgettext``, ``_dcpf``
+
+  Translation in specified domain and category with context and string formatting.
+
+  .. code-block:: jinja
+  
+      {{ dcpfgettext('context', 'domain', 'String', 'category', arg, ..) }}
+      {{ _dcpf('context', 'domain', 'String', 'category', arg, ..) }}
+
+* ``dcngettext``, ``_dcn``
+
+  Pluralized translation in specified domain and category.
+
+  .. code-block:: jinja
+  
+      {{ dcngettext('domain', 'Singular', 'Plural', 'category') }}
+      {{ _dcn('domain', 'Singular', 'Plural', 'category') }}
+
+* ``dcnfgettext``, ``_dcnf``
+
+  Pluralized translation in specified domain and category with string formatting.
+
+  .. code-block:: jinja
+  
+      {{ dcnfgettext('domain', 'Singular', 'Plural', 'category', arg, ..) }}
+      {{ _dcnf('domain', 'Singular', 'Plural', 'category', arg, ..) }}
+
+* ``dcnpgettext``, ``_dcnp``
+
+  Pluralized translation in specified domain and category with context.
+
+  .. code-block:: jinja
+  
+      {{ dcnpgettext('context', 'domain', 'Singular', 'Plural', 'category') }}
+      {{ _dcnp('context', 'domain', 'Singular', 'Plural', 'category') }}
+
+* ``dcnpfgettext``, ``_dcnpf``
+
+  Pluralized translation in specified domain and category with context and string formatting.
+
+  .. code-block:: jinja
+  
+      {{ dcnpfgettext('context', 'domain', 'Singular', 'Plural', 'category', arg, ..) }}
+      {{ _dcnpf('context', 'domain', 'Singular', 'Plural', 'category', arg, ..) }}
+
+
+Workflow
+--------
+
+I recommend again that you read the `GNU gettext documentation`_ to learn more about the correct workflow when working with translations. Especially when working with distributed translators, coordinating source code which is constantly changing, translations which need to be updated and the timelag between these two parties is more complex than you may think. The workflow in a nutshell though is:
+
+* the programmer prepares source code by wrapping strings in ``gettext`` functions
+* the translation coordinator runs the extraction script which extracts strings into ``.pot`` files
+* the translation coordinator merges the newly extracted source strings with the latest translated
+  ``.po`` files using the `msgmerge`_ utility
+  
+    * this step is crucial, ``msgmerge`` does a lot of automagic to keep translations and source
+      files in sync, study its behavior well
+    * you typically want a script that does the merging for each of your target languages automatically,
+      since the number of files to merge grows exponentially with each new target language/category/domain
+      
+* the translation coordinator distributes the updated ``.po`` files to the translators
+
+    * you may use a web based tool like `Pootle`_ or similar commercial products for this
+
+* the translators translate the strings
+
+    * if a translation is unclear, the string should be marked ``fuzzy`` and a comment should be added
+    * translators need to choose a tool suited for the job, which helps find untranslated or fuzzy strings
+      and which honors and displays the meta information of each string
+    * a good local tool is `Poedit`_
+    
+* the translated files are checked for quality, e.g. whether ``sprintf`` formatted strings are still correct
+
+    * if clarification is necessary, possibly the source code should be changed to add a comment or context
+    * remember that it's important to keep this process repeatable and automated, manual edits to anything
+      but the ``msgstr`` and *translator-comment* nodes in the ``.po`` files will be lost during the next
+      merge as will ad-hoc communication with translators
+      
+* the translation coordinator merges the translated files back into the project
+
+    * if the extracted ``.pot`` files have not changed since the ``.po`` files have been sent out, simply
+      replacing the ``.po`` files is fine
+    * otherwise ``msgmerge`` should be used to merge the translations with the new sources
+    * again, you typically want to have a script that automates this
+    
+* the ``.po`` files are compiled to ``.mo`` files using `msgfmt`_
+* rinse, repeat
+
+
+.. _`gettext`:                   http://www.php.net/gettext
+.. _`documentation`:             http://php.net/manual/en/function.gettext.php
+.. _`sprintf`:                   http://php.net/sprintf
+.. _`GNU gettext documentation`: http://www.gnu.org/software/gettext/manual/gettext.html
+.. _`msgmerge`:                  http://www.gnu.org/software/gettext/manual/gettext.html#msgmerge-Invocation
+.. _`msgfmt`:                    http://www.gnu.org/software/gettext/manual/gettext.html#msgfmt-Invocation
+.. _`Pootle`:                    http://translate.readthedocs.org/projects/pootle/en/latest/index.html
+.. _`Poedit`:                    http://www.poedit.net
+.. _`Kunststube\\POTools`:       http://github.com/deceze/Kunststube-POTools

--- a/doc/gettext.rst
+++ b/doc/gettext.rst
@@ -274,7 +274,7 @@ Note that the argument order may differ between function and filter syntax. The 
   
       {{ 'Singular'|dnpgettext('Plural', num, 'domain', 'context') }}
       {{ 'Singular'|_dnp('Plural', num, 'domain', 'context') }}
-      {{ dnpgettext('context, 'domain', 'Singular', 'Plural', num) }}
+      {{ dnpgettext('context', 'domain', 'Singular', 'Plural', num) }}
       {{ _dnp('context', 'domain', 'Singular', 'Plural', num) }}
 
 * ``dcgettext``, ``_dc``

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,6 +7,7 @@ Twig Extensions
     debug
     text
     i18n
+    gettext
 
 The Twig Extensions repository provides several useful extensions for Twig:
 
@@ -16,3 +17,6 @@ The Twig Extensions repository provides several useful extensions for Twig:
 
 * :doc:`I18n <i18n>`: Adds internationalization support via the ``gettext``
   library.
+
+* :doc:`Gettext <gettext>`: Adds a complete interface for the ``gettext`` extension,
+  including automated native string extraction.

--- a/lib/Twig/Extensions/Extension/Gettext.php
+++ b/lib/Twig/Extensions/Extension/Gettext.php
@@ -13,172 +13,179 @@ class Twig_Extensions_Extension_Gettext extends Twig_Extension {
     }
     
     public function getFunctions() {
-        $gettext      = new Twig_Function_Function('gettext');
-        $fgettext     = new Twig_Function_Method($this, 'fgettext');
-        $pgettext     = new Twig_Function_Method($this, 'pgettext');
-        $pfgettext    = new Twig_Function_Method($this, 'pfgettext');
-        $ngettext     = new Twig_Function_Function('ngettext');
-        $nfgettext    = new Twig_Function_Method($this, 'nfgettext');
-        $npgettext    = new Twig_Function_Method($this, 'npgettext');
-        $npfgettext   = new Twig_Function_Method($this, 'npfgettext');
-        $dgettext     = new Twig_Function_Function('dgettext');
-        $dfgettext    = new Twig_Function_Method($this, 'dfgettext');
-        $dpgettext    = new Twig_Function_Method($this, 'dpgettext');
-        $dpfgettext   = new Twig_Function_Method($this, 'dpfgettext');
-        $dngettext    = new Twig_Function_Function('dngettext');
-        $dnfgettext   = new Twig_Function_Method($this, 'dnfgettext');
-        $dnpgettext   = new Twig_Function_Method($this, 'dnpgettext');
-        $dnpfgettext  = new Twig_Function_Method($this, 'dnpfgettext');
-        $dcgettext    = new Twig_Function_Function('dcgettext');
-        $dcfgettext   = new Twig_Function_Method($this, 'dcfgettext');
-        $dcpgettext   = new Twig_Function_Method($this, 'dcpgettext');
-        $dcpfgettext  = new Twig_Function_Method($this, 'dcpfgettext');
-        $dcngettext   = new Twig_Function_Function('dcngettext');
-        $dcnfgettext  = new Twig_Function_Method($this, 'dcnfgettext');
-        $dcnpgettext  = new Twig_Function_Method($this, 'dcnpgettext');
-        $dcnpfgettext = new Twig_Function_Method($this, 'dcnpfgettext');
+        $gettext     = new Twig_Function_Function('gettext');
+        $pgettext    = new Twig_Function_Method($this, 'pgettext');
+        $ngettext    = new Twig_Function_Function('ngettext');
+        $npgettext   = new Twig_Function_Method($this, 'npgettext');
+        $dgettext    = new Twig_Function_Function('dgettext');
+        $dpgettext   = new Twig_Function_Method($this, 'dpgettext');
+        $dngettext   = new Twig_Function_Function('dngettext');
+        $dnpgettext  = new Twig_Function_Method($this, 'dnpgettext');
+        $dcgettext   = new Twig_Function_Method($this, 'dcgettext');
+        $dcpgettext  = new Twig_Function_Method($this, 'dcpgettext');
+        $dcngettext  = new Twig_Function_Method($this, 'dcngettext');
+        $dcnpgettext = new Twig_Function_Method($this, 'dcnpgettext');
         
         $functions = array(
-            'gettext'      => $gettext,
-            'fgettext'     => $fgettext,
-            'pgettext'     => $pgettext,
-            'pfgettext'    => $pfgettext,
-            'ngettext'     => $ngettext,
-            'nfgettext'    => $nfgettext,
-            'npgettext'    => $npgettext,
-            'npfgettext'   => $npfgettext,
-            'dgettext'     => $dgettext,
-            'dfgettext'    => $dfgettext,
-            'dpgettext'    => $dpgettext,
-            'dpfgettext'   => $dpfgettext,
-            'dngettext'    => $dngettext,
-            'dnfgettext'   => $dnfgettext,
-            'dnpgettext'   => $dnpgettext,
-            'dnpfgettext'  => $dnpfgettext,
-            'dcgettext'    => $dcgettext,
-            'dcfgettext'   => $dcfgettext,
-            'dcpgettext'   => $dcpgettext,
-            'dcpfgettext'  => $dcpfgettext,
-            'dcngettext'   => $dcngettext,
-            'dcnfgettext'  => $dcnfgettext,
-            'dcnpgettext'  => $dcnpgettext,
-            'dcnpfgettext' => $dcnpfgettext
+            'gettext'     => $gettext,
+            'pgettext'    => $pgettext,
+            'ngettext'    => $ngettext,
+            'npgettext'   => $npgettext,
+            'dgettext'    => $dgettext,
+            'dpgettext'   => $dpgettext,
+            'dngettext'   => $dngettext,
+            'dnpgettext'  => $dnpgettext,
+            'dcgettext'   => $dcgettext,
+            'dcpgettext'  => $dcpgettext,
+            'dcngettext'  => $dcngettext,
+            'dcnpgettext' => $dcnpgettext
         );
         
         if ($this->useShortnames) {
             $functions += array(
-                '_'      => $gettext,
-                '_f'     => $fgettext,
-                '_p'     => $pgettext,
-                '_pf'    => $pfgettext,
-                '_n'     => $ngettext,
-                '_nf'    => $nfgettext,
-                '_np'    => $npgettext,
-                '_npf'   => $npfgettext,
-                '_d'     => $dgettext,
-                '_df'    => $dfgettext,
-                '_dp'    => $dpgettext,
-                '_dpf'   => $dpfgettext,
-                '_dn'    => $dngettext,
-                '_dnf'   => $dnfgettext,
-                '_dnp'   => $dnpgettext,
-                '_dnpf'  => $dnpfgettext,
-                '_dc'    => $dcgettext,
-                '_dcf'   => $dcfgettext,
-                '_dcp'   => $dcpgettext,
-                '_dcpf'  => $dcpfgettext,
-                '_dcn'   => $dcngettext,
-                '_dcnf'  => $dcnfgettext,
-                '_dcnp'  => $dcnpgettext,
-                '_dcnpf' => $dcnpfgettext
+                '_'     => $gettext,
+                '_p'    => $pgettext,
+                '_n'    => $ngettext,
+                '_np'   => $npgettext,
+                '_d'    => $dgettext,
+                '_dp'   => $dpgettext,
+                '_dn'   => $dngettext,
+                '_dnp'  => $dnpgettext,
+                '_dc'   => $dcgettext,
+                '_dcp'  => $dcpgettext,
+                '_dcn'  => $dcngettext,
+                '_dcnp' => $dcnpgettext
             );
         }
         
         return $functions;
     }
     
-    public function fgettext($message) {
-        $args = func_get_args();
-        return vsprintf(gettext($message), array_slice($args, 1));
+    public function getFilters() {
+        $gettext     = new Twig_Filter_Function('gettext');
+        $pgettext    = new Twig_Filter_Method($this, 'pgettextFilter');
+        $ngettext    = new Twig_Filter_Function('ngettext');
+        $npgettext   = new Twig_Filter_Method($this, 'npgettextFilter');
+        $dgettext    = new Twig_Filter_Method($this, 'dgettextFilter');
+        $dpgettext   = new Twig_Filter_Method($this, 'dpgettextFilter');
+        $dngettext   = new Twig_Filter_Method($this, 'dngettextFilter');
+        $dnpgettext  = new Twig_Filter_Method($this, 'dnpgettextFilter');
+        $dcgettext   = new Twig_Filter_Method($this, 'dcgettextFilter');
+        $dcpgettext  = new Twig_Filter_Method($this, 'dcpgettextFilter');
+        $dcngettext  = new Twig_Filter_Method($this, 'dcngettextFilter');
+        $dcnpgettext = new Twig_Filter_Method($this, 'dcnpgettextFilter');
+        
+        $filters = array(
+            'gettext'     => $gettext,
+            'pgettext'    => $pgettext,
+            'ngettext'    => $ngettext,
+            'npgettext'   => $npgettext,
+            'dgettext'    => $dgettext,
+            'dpgettext'   => $dpgettext,
+            'dngettext'   => $dngettext,
+            'dnpgettext'  => $dnpgettext,
+            'dcgettext'   => $dcgettext,
+            'dcpgettext'  => $dcpgettext,
+            'dcngettext'  => $dcngettext,
+            'dcnpgettext' => $dcnpgettext,
+            'sprintf'     => new Twig_Filter_Method($this, 'sprintf')
+        );
+        
+        if ($this->useShortnames) {
+            $filters += array(
+                '_'     => $gettext,
+                '_p'    => $pgettext,
+                '_n'    => $ngettext,
+                '_np'   => $npgettext,
+                '_d'    => $dgettext,
+                '_dp'   => $dpgettext,
+                '_dn'   => $dngettext,
+                '_dnp'  => $dnpgettext,
+                '_dc'   => $dcgettext,
+                '_dcp'  => $dcpgettext,
+                '_dcn'  => $dcngettext,
+                '_dcnp' => $dcnpgettext
+            );
+        }
+        
+        return $filters;
     }
     
     public function pgettext($context, $message) {
         return gettext($context . "\04" . $message);
     }
     
-    public function pfgettext($context, $message) {
-        $args = func_get_args();
-        return vsprintf($this->pgettext($context, $message), array_slice($args, 2));
-    }
-    
-    public function nfgettext($msgid1, $msgid2, $n) {
-        $args = func_get_args();
-        return vsprintf(ngettext($msgid1, $msgid2, $n), array_slice($args, 3));
-    }
-    
     public function npgettext($context, $msgid1, $msgid2, $n) {
         return ngettext($context . "\04" . $msgid1, $context . "\04" . $msgid2, $n);
-    }
-    
-    public function npfgettext($context, $msgid1, $msgid2, $n) {
-        $args = func_get_args();
-        return vsprintf($this->npgettext($context, $msgid1, $msgid2, $n), array_slice($args, 4));
-    }
-    
-    public function dfgettext($domain, $message) {
-        $args = func_get_args();
-        return vsprintf(dgettext($domain, $message), array_slice($args, 2));
     }
     
     public function dpgettext($context, $domain, $message) {
         return dgettext($domain, $context . "\04" . $message);
     }
 
-    public function dpfgettext($context, $domain, $message) {
-        $args = func_get_args();
-        return vsprintf($this->dpgettext($context, $domain, $message), array_slice($args, 3));
-    }
-    
-    public function dnfgettext($domain, $msgid1, $msgid2, $n) {
-        $args = func_get_args();
-        return vsprintf(dngettext($domain, $msgid1, $msgid2, $n), array_slice($args, 4));
-    }
-
     public function dnpgettext($context, $domain, $msgid1, $msgid2, $n) {
         return dngettext($domain, $context . "\04" . $msgid1, $context . "\04" . $msgid2, $n);
     }
 
-    public function dnpfgettext($context, $domain, $msgid1, $msgid2, $n) {
-        $args = func_get_args();
-        return vsprintf($this->dnpgettext($context, $domain, $msgid1, $msgid2, $n), array_slice($args, 5));
-    }
-
-    public function dcfgettext($domain, $message, $category) {
-        $args = func_get_args();
-        return vsprintf(dcgettext($domain, $message, $category), array_slice($args, 3));
+    public function dcgettext($domain, $message, $category) {
+        return dcgettext($domain, $message, constant($category));
     }
     
     public function dcpgettext($context, $domain, $message, $category) {
-        return dcgettext($domain, $context . "\04" . $message, $category);
+        return dcgettext($domain, $context . "\04" . $message, constant($category));
     }
     
-    public function dcpfgettext($context, $domain, $message, $category) {
-        $args = func_get_args();
-        return vsprintf($this->dcpgettext($context, $domain, $message, $category), array_slice($args, 4));
-    }
-    
-    public function dcnfgettext($domain, $msgid1, $msgid2, $n, $category) {
-        $args = func_get_args();
-        return vsprintf(dcngettext($domain, $msgid1, $msgid2, $n, $category), array_slice($args, 5));
+    public function dcngettext($domain, $msgid1, $msgid2, $n, $category) {
+        return dcngettext($domain, $msgid1, $msgid2, $n, constant($category));
     }
     
     public function dcnpgettext($context, $domain, $msgid1, $msgid2, $n, $category) {
-        return dcngettext($domain, $context . "\04" . $msgid1, $context . "\04" . $msgid2, $n, $category);
+        return dcngettext($domain, $context . "\04" . $msgid1, $context . "\04" . $msgid2, $n, constant($category));
     }
     
-    public function dcnpfgettext($context, $domain, $msgid1, $msgid2, $n, $category) {
+    public function pgettextFilter($message, $context) {
+        return $this->pgettext($context, $message);
+    }
+    
+    public function npgettextFilter($msgid1, $msgid2, $n, $context) {
+        return $this->npgettext($context, $msgid1, $msgid2, $context);
+    }
+    
+    public function dgettextFilter($message, $domain) {
+        return dgettext($domain, $message);
+    }
+    
+    public function dpgettextFilter($message, $domain, $context) {
+        return $this->dpgettext($context, $domain, $message);
+    }
+    
+    public function dngettextFilter($msgid1, $msgid2, $n, $domain) {
+        return dngettext($domain, $msgid1, $msgid2, $n);
+    }
+    
+    public function dnpgettextFilter($msgid1, $msgid2, $n, $domain, $context) {
+        return $this->dnpgettext($context, $domain, $msgid1, $msgid2, $n);
+    }
+    
+    public function dcgettextFilter($message, $domain, $category) {
+        return $this->dcgettext($domain, $message, $category);
+    }
+    
+    public function dcpgettextFilter($message, $domain, $category, $context) {
+        return $this->dcpgettext($context, $domain, $message, $category);
+    }
+    
+    public function dcngettextFilter($msgid1, $msgid2, $n, $domain, $category) {
+        return $this->dcngettext($domain, $msgid1, $msgid2, $n, $category);
+    }
+    
+    public function dcnpgettextFilter($msgid1, $msgid2, $n, $domain, $category, $context) {
+        return $this->dcngettext($context, $domain, $msgid1, $msgid2, $n, $category);
+    }
+    
+    public function sprintf($string /*, $arg, ... */) {
         $args = func_get_args();
-        return vsprintf($this->dcnpgettext($context, $domain, $msgid1, $msgid2, $n, $category), array_slice($args, 6));
+        return vsprintf($string, array_slice($args, 1));
     }
     
 }

--- a/lib/Twig/Extensions/Extension/Gettext.php
+++ b/lib/Twig/Extensions/Extension/Gettext.php
@@ -1,0 +1,184 @@
+<?php
+
+class Twig_Extensions_Extension_Gettext extends Twig_Extension {
+    
+    protected $useShortnames = true;
+    
+    public function __construct($useShortnames = true) {
+        $this->useShortnames = $useShortnames;
+    }
+    
+    public function getName() {
+        return 'gettext';
+    }
+    
+    public function getFunctions() {
+        $gettext      = new Twig_Function_Function('gettext');
+        $fgettext     = new Twig_Function_Method($this, 'fgettext');
+        $pgettext     = new Twig_Function_Method($this, 'pgettext');
+        $pfgettext    = new Twig_Function_Method($this, 'pfgettext');
+        $ngettext     = new Twig_Function_Function('ngettext');
+        $nfgettext    = new Twig_Function_Method($this, 'nfgettext');
+        $npgettext    = new Twig_Function_Method($this, 'npgettext');
+        $npfgettext   = new Twig_Function_Method($this, 'npfgettext');
+        $dgettext     = new Twig_Function_Function('dgettext');
+        $dfgettext    = new Twig_Function_Method($this, 'dfgettext');
+        $dpgettext    = new Twig_Function_Method($this, 'dpgettext');
+        $dpfgettext   = new Twig_Function_Method($this, 'dpfgettext');
+        $dngettext    = new Twig_Function_Function('dngettext');
+        $dnfgettext   = new Twig_Function_Method($this, 'dnfgettext');
+        $dnpgettext   = new Twig_Function_Method($this, 'dnpgettext');
+        $dnpfgettext  = new Twig_Function_Method($this, 'dnpfgettext');
+        $dcgettext    = new Twig_Function_Function('dcgettext');
+        $dcfgettext   = new Twig_Function_Method($this, 'dcfgettext');
+        $dcpgettext   = new Twig_Function_Method($this, 'dcpgettext');
+        $dcpfgettext  = new Twig_Function_Method($this, 'dcpfgettext');
+        $dcngettext   = new Twig_Function_Function('dcngettext');
+        $dcnfgettext  = new Twig_Function_Method($this, 'dcnfgettext');
+        $dcnpgettext  = new Twig_Function_Method($this, 'dcnpgettext');
+        $dcnpfgettext = new Twig_Function_Method($this, 'dcnpfgettext');
+        
+        $functions = array(
+            'gettext'      => $gettext,
+            'fgettext'     => $fgettext,
+            'pgettext'     => $pgettext,
+            'pfgettext'    => $pfgettext,
+            'ngettext'     => $ngettext,
+            'nfgettext'    => $nfgettext,
+            'npgettext'    => $npgettext,
+            'npfgettext'   => $npfgettext,
+            'dgettext'     => $dgettext,
+            'dfgettext'    => $dfgettext,
+            'dpgettext'    => $dpgettext,
+            'dpfgettext'   => $dpfgettext,
+            'dngettext'    => $dngettext,
+            'dnfgettext'   => $dnfgettext,
+            'dnpgettext'   => $dnpgettext,
+            'dnpfgettext'  => $dnpfgettext,
+            'dcgettext'    => $dcgettext,
+            'dcfgettext'   => $dcfgettext,
+            'dcpgettext'   => $dcpgettext,
+            'dcpfgettext'  => $dcpfgettext,
+            'dcngettext'   => $dcngettext,
+            'dcnfgettext'  => $dcnfgettext,
+            'dcnpgettext'  => $dcnpgettext,
+            'dcnpfgettext' => $dcnpfgettext
+        );
+        
+        if ($this->useShortnames) {
+            $functions += array(
+                '_'      => $gettext,
+                '_f'     => $fgettext,
+                '_p'     => $pgettext,
+                '_pf'    => $pfgettext,
+                '_n'     => $ngettext,
+                '_nf'    => $nfgettext,
+                '_np'    => $npgettext,
+                '_npf'   => $npfgettext,
+                '_d'     => $dgettext,
+                '_df'    => $dfgettext,
+                '_dp'    => $dpgettext,
+                '_dpf'   => $dpfgettext,
+                '_dn'    => $dngettext,
+                '_dnf'   => $dnfgettext,
+                '_dnp'   => $dnpgettext,
+                '_dnpf'  => $dnpfgettext,
+                '_dc'    => $dcgettext,
+                '_dcf'   => $dcfgettext,
+                '_dcp'   => $dcpgettext,
+                '_dcpf'  => $dcpfgettext,
+                '_dcn'   => $dcngettext,
+                '_dcnf'  => $dcnfgettext,
+                '_dcnp'  => $dcnpgettext,
+                '_dcnpf' => $dcnpfgettext
+            );
+        }
+        
+        return $functions;
+    }
+    
+    public function fgettext($message) {
+        $args = func_get_args();
+        return vsprintf(gettext($message), array_slice($args, 1));
+    }
+    
+    public function pgettext($context, $message) {
+        return gettext($context . "\04" . $message);
+    }
+    
+    public function pfgettext($context, $message) {
+        $args = func_get_args();
+        return vsprintf($this->pgettext($context, $message), array_slice($args, 2));
+    }
+    
+    public function nfgettext($msgid1, $msgid2, $n) {
+        $args = func_get_args();
+        return vsprintf(ngettext($msgid1, $msgid2, $n), array_slice($args, 3));
+    }
+    
+    public function npgettext($context, $msgid1, $msgid2, $n) {
+        return ngettext($context . "\04" . $msgid1, $context . "\04" . $msgid2, $n);
+    }
+    
+    public function npfgettext($context, $msgid1, $msgid2, $n) {
+        $args = func_get_args();
+        return vsprintf($this->npgettext($context, $msgid1, $msgid2, $n), array_slice($args, 4));
+    }
+    
+    public function dfgettext($domain, $message) {
+        $args = func_get_args();
+        return vsprintf(dgettext($domain, $message), array_slice($args, 2));
+    }
+    
+    public function dpgettext($context, $domain, $message) {
+        return dgettext($domain, $context . "\04" . $message);
+    }
+
+    public function dpfgettext($context, $domain, $message) {
+        $args = func_get_args();
+        return vsprintf($this->dpgettext($context, $domain, $message), array_slice($args, 3));
+    }
+    
+    public function dnfgettext($domain, $msgid1, $msgid2, $n) {
+        $args = func_get_args();
+        return vsprintf(dngettext($domain, $msgid1, $msgid2, $n), array_slice($args, 4));
+    }
+
+    public function dnpgettext($context, $domain, $msgid1, $msgid2, $n) {
+        return dngettext($domain, $context . "\04" . $msgid1, $context . "\04" . $msgid2, $n);
+    }
+
+    public function dnpfgettext($context, $domain, $msgid1, $msgid2, $n) {
+        $args = func_get_args();
+        return vsprintf($this->dnpgettext($context, $domain, $msgid1, $msgid2, $n), array_slice($args, 5));
+    }
+
+    public function dcfgettext($domain, $message, $category) {
+        $args = func_get_args();
+        return vsprintf(dcgettext($domain, $message, $category), array_slice($args, 3));
+    }
+    
+    public function dcpgettext($context, $domain, $message, $category) {
+        return dcgettext($domain, $context . "\04" . $message, $category);
+    }
+    
+    public function dcpfgettext($context, $domain, $message, $category) {
+        $args = func_get_args();
+        return vsprintf($this->dcpgettext($context, $domain, $message, $category), array_slice($args, 4));
+    }
+    
+    public function dcnfgettext($domain, $msgid1, $msgid2, $n, $category) {
+        $args = func_get_args();
+        return vsprintf(dcngettext($domain, $msgid1, $msgid2, $n, $category), array_slice($args, 5));
+    }
+    
+    public function dcnpgettext($context, $domain, $msgid1, $msgid2, $n, $category) {
+        return dcngettext($domain, $context . "\04" . $msgid1, $context . "\04" . $msgid2, $n, $category);
+    }
+    
+    public function dcnpfgettext($context, $domain, $msgid1, $msgid2, $n, $category) {
+        $args = func_get_args();
+        return vsprintf($this->dcnpgettext($context, $domain, $msgid1, $msgid2, $n, $category), array_slice($args, 6));
+    }
+    
+}

--- a/lib/Twig/Extensions/Extension/Gettext.php
+++ b/lib/Twig/Extensions/Extension/Gettext.php
@@ -87,8 +87,7 @@ class Twig_Extensions_Extension_Gettext extends Twig_Extension {
             'dcgettext'   => $dcgettext,
             'dcpgettext'  => $dcpgettext,
             'dcngettext'  => $dcngettext,
-            'dcnpgettext' => $dcnpgettext,
-            'sprintf'     => new Twig_Filter_Method($this, 'sprintf')
+            'dcnpgettext' => $dcnpgettext
         );
         
         if ($this->useShortnames) {
@@ -181,11 +180,6 @@ class Twig_Extensions_Extension_Gettext extends Twig_Extension {
     
     public function dcnpgettextFilter($msgid1, $msgid2, $n, $domain, $category, $context) {
         return $this->dcngettext($context, $domain, $msgid1, $msgid2, $n, $category);
-    }
-    
-    public function sprintf($string /*, $arg, ... */) {
-        $args = func_get_args();
-        return vsprintf($string, array_slice($args, 1));
     }
     
 }

--- a/lib/Twig/Extensions/Extension/Gettext.php
+++ b/lib/Twig/Extensions/Extension/Gettext.php
@@ -148,7 +148,7 @@ class Twig_Extensions_Extension_Gettext extends Twig_Extension {
     }
     
     public function npgettextFilter($msgid1, $msgid2, $n, $context) {
-        return $this->npgettext($context, $msgid1, $msgid2, $context);
+        return $this->npgettext($context, $msgid1, $msgid2, $n);
     }
     
     public function dgettextFilter($message, $domain) {

--- a/lib/Twig/Extensions/Extension/Gettext/Extractor.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Extractor.php
@@ -35,32 +35,11 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         
         $source = file_get_contents($file);
         $tokens = $this->lexer->tokenize($source);
-        $tokens = $this->extractComments($tokens);
-        $node   = $this->parser->parse($tokens);
+        $this->comments = $this->lexer->getCommentTokens();
+        $node = $this->parser->parse($tokens);
         $this->processNode($node);
         
         return $this->strings;
-    }
-    
-    protected function extractComments(Twig_TokenStream $stream) {
-        $tokens = array();
-        $this->comments = array();
-
-        while (!$stream->isEOF()) {
-            $token = $stream->next();
-            
-            switch ($token->getType()) {
-                case Twig_Extensions_Extension_Gettext_Token::COMMENT :
-                    $this->comments[] = $token;
-                    break;
-                default :
-                    $tokens[] = $token;
-            }
-        }
-        
-        $tokens[] = $stream->getCurrent();
-        
-        return new Twig_TokenStream($tokens, $stream->getFilename());
     }
     
     protected function getPreceedingCommentNode($lineno) {

--- a/lib/Twig/Extensions/Extension/Gettext/Extractor.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Extractor.php
@@ -274,7 +274,7 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         }
         
         if ($comment = $this->getPreceedingCommentNode($node->getLine())) {
-            $POString->setExtractedComments(trim($comment->getValue()));
+            $POString->addExtractedComment(trim($comment->getValue()));
         }
         $POString->addReference(sprintf("$this->file:%d", $node->getLine()));
         $this->strings[] = $POString;

--- a/lib/Twig/Extensions/Extension/Gettext/Extractor.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Extractor.php
@@ -1,0 +1,315 @@
+<?php
+
+class Twig_Extensions_Extension_Gettext_Extractor {
+    
+    protected $strings = array();
+    
+    protected $comments = array();
+    
+    protected $file;
+    
+    protected $lexer;
+    
+    protected $parser;
+    
+    protected $POStringFactory;
+    
+    public function __construct(Twig_Extensions_Extension_Gettext_POString_Factory_Interface $POStringFactory) {
+        $this->POStringFactory = $POStringFactory;
+        
+        $twig         = new Twig_Environment(new Twig_Loader_String);
+        $this->lexer  = new Twig_Extensions_Extension_Gettext_Lexer($twig);
+        $this->parser = new Twig_Parser($twig);
+    }
+    
+    public function extractFile($file) {
+        $this->strings = array();
+        $this->file    = $file;
+        
+        $source = file_get_contents($file);
+        $tokens = $this->lexer->tokenize($source);
+        $tokens = $this->extractComments($tokens);
+        $node   = $this->parser->parse($tokens);
+        $this->processNode($node);
+        
+        return $this->strings;
+    }
+    
+    protected function extractComments(Twig_TokenStream $stream) {
+        $tokens = array();
+        
+        while (!$stream->isEOF()) {
+            $token = $stream->next();
+            
+            switch ($token->getType()) {
+                case Twig_Extensions_Extension_Gettext_Token::COMMENT :
+                    $this->comments[] = $token;
+                    break;
+                default :
+                    $tokens[] = $token;
+            }
+        }
+        
+        $tokens[] = $stream->getCurrent();
+        
+        return new Twig_TokenStream($tokens, $stream->getFilename());
+    }
+    
+    protected function getPreceedingCommentNode($lineno) {
+        $commentNode = null;
+        foreach ($this->comments as $comment) {
+            if ($comment->getLine() <= $lineno) {
+                $commentNode = $comment;
+            } else {
+                break;
+            }
+        }
+        if (!$commentNode) {
+            return;
+        }
+        
+        $lines = substr_count($commentNode->getValue(), "\n") + 1;
+        if ($commentNode->getLine() + $lines !=  $lineno) {
+            return;
+        }
+        
+        return $commentNode;
+    }
+    
+    protected function processNode(Twig_NodeInterface $node) {
+        if ($node instanceof Twig_Node_Expression_Function) {
+            $this->processFunctionNode($node);
+        }
+    
+        foreach ($node as $child) {
+            if ($child instanceof Twig_NodeInterface) {
+                $this->processNode($child);
+            }
+        }
+    }
+    
+    protected function processFunctionNode(Twig_Node_Expression_Function $node) {
+        switch ($node->getAttribute('name')) {
+            case '_' :
+            case 'gettext' :
+            case '_f' :
+            case 'fgettext' :
+                $this->gettext($node);
+                break;
+            case '_p' :
+            case 'pgettext' :
+            case '_pf' :
+            case 'pfgettext' :
+                $this->pgettext($node);
+                break;
+            case '_n' :
+            case 'ngettext' :
+            case '_nf' :
+            case 'nfgettext' :
+                $this->ngettext($node);
+                break;
+            case '_np' :
+            case 'npgettext' :
+            case '_npf' :
+            case 'npfgettext' :
+                $this->npgettext($node);
+                break;
+            case '_d' :
+            case 'dgettext' :
+            case '_df' :
+            case 'dfgettext' :
+                $this->dgettext($node);
+                break;
+            case '_dp' :
+            case 'dpgettext' :
+            case '_dpf' :
+            case 'dpfgettext' :
+                $this->dpgettext($node);
+                break;
+            case '_dn' :
+            case 'dngettext' :
+            case '_dnf' :
+            case 'dnfgettext' :
+                $this->dngettext($node);
+                break;
+            case '_dnp' :
+            case 'dnpgettext' :
+            case '_dnpf' :
+            case 'dnpfgettext' :
+                $this->dnpgettext($node);
+                break;
+            case '_dc' :
+            case 'dcgettext' :
+            case '_dcf' :
+            case 'dcfgettext' :
+                $this->dcgettext($node);
+                break;
+            case '_dcp' :
+            case 'dcpgettext' :
+            case '_dcpf' :
+            case 'dcpfgettext' :
+                $this->dcpgettext($node);
+                break;
+            case '_dcn' :
+            case 'dcngettext' :
+            case '_dcnf' :
+            case 'dcnfgettext' :
+                $this->dcngettext($node);
+                break;
+            case '_dcnp' :
+            case 'dcnpgettext' :
+            case '_dcnpf' :
+            case 'dcnpfgettext' :
+                $this->dcnpgettext($node);
+                break;
+        }
+    }
+    
+    protected function gettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 1, 'Twig_Node_Expression_Constant');
+        $this->pushEntry($this->getPOString($arguments[0]->getAttribute('value')), $node->getLine());
+    }
+    
+    protected function pgettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 2, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
+        $string = $this->getPOString($arguments[1]->getAttribute('value'));
+        $string->setMsgctxt($arguments[0]->getAttribute('value'));
+        $this->pushEntry($string, $node->getLine());
+    }
+        
+    protected function ngettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 3, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null);
+        $string = $this->getPOString($arguments[0]->getAttribute('value'), $arguments[1]->getAttribute('value'));
+        $this->pushEntry($string, $node->getLine());
+    }
+        
+    protected function npgettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 4, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null);
+        $string = $this->getPOString($arguments[1]->getAttribute('value'), $arguments[2]->getAttribute('value'));
+        $string->setMsgctxt($arguments[0]->getAttribute('value'));
+        $this->pushEntry($string, $node->getLine());
+    }
+        
+    protected function dgettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 2, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
+        $string = $this->getPOString($arguments[1]->getAttribute('value'));
+        $string->setDomain($arguments[0]->getAttribute('value'));
+        $this->pushEntry($string, $node->getLine());
+    }
+        
+    protected function dpgettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 3, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
+        $string = $this->getPOString($arguments[2]->getAttribute('value'));
+        $string->setMsgctxt($arguments[1]->getAttribute('value'));
+        $string->setDomain($arguments[0]->getAttribute('value'));
+        $this->pushEntry($string, $node->getLine());
+    }
+        
+    protected function dngettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 4, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null);
+        $string = $this->getPOString($arguments[1]->getAttribute('value'), $arguments[2]->getAttribute('value'));
+        $string->setDomain($arguments[0]->getAttribute('value'));
+        $this->pushEntry($string, $node->getLine());
+    }
+    
+    protected function dnpgettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 5, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null);
+        $string = $this->getPOString($arguments[2]->getAttribute('value'), $arguments[3]->getAttribute('value'));
+        $string->setDomain($arguments[0]->getAttribute('value'));
+        $string->setMsgctxt($arguments[1]->getAttribute('value'));
+        $this->pushEntry($string, $node->getLine());
+    }
+    
+    protected function dcgettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 3, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
+        $string = $this->getPOString($arguments[1]->getAttribute('value'));
+        $string->setDomain($arguments[0]->getAttribute('value'));
+        $string->setCategory(constant($arguments[2]->getAttribute('value')));
+        $this->pushEntry($string, $node->getLine());
+    }
+    
+    protected function dcpgettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 4, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
+        $string = $this->getPOString($arguments[1]->getAttribute('value'));
+        $string->setDomain($arguments[0]->getAttribute('value'));
+        $string->setMsgctxt($arguments[1]->getAttribute('value'));
+        $string->setCategory(constant($arguments[3]->getAttribute('value')));
+        $this->pushEntry($string, $node->getLine());
+    }
+    
+    protected function dcngettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 5, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null, 'Twig_Node_Expression_Constant');
+        $string = $this->getPOString($arguments[1]->getAttribute('value'), $arguments[2]->getAttribute('value'));
+        $string->setDomain($arguments[0]->getAttribute('value'));
+        $string->setCategory(constant($arguments[4]->getAttribute('value')));
+        $this->pushEntry($string, $node->getLine());
+    }
+    
+    protected function dcnpgettext(Twig_Node_Expression_Function $node) {
+        $arguments = $this->validateArguments($node, 6, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null, 'Twig_Node_Expression_Constant');
+        $string = $this->getPOString($arguments[2]->getAttribute('value'), $arguments[3]->getAttribute('value'));
+        $string->setDomain($arguments[0]->getAttribute('value'));
+        $string->setMsgctxt($arguments[1]->getAttribute('value'));
+        $string->setCategory(constant($arguments[5]->getAttribute('value')));
+        $this->pushEntry($string, $node->getLine());
+    }
+        
+    protected function getArguments(Twig_Node_Expression_Function $functionNode) {
+        $arguments = array();
+        foreach ($functionNode->getNode('arguments') as $argument) {
+            $arguments[] = $argument;
+        }
+        return $arguments;
+    }
+    
+    protected function validateArguments(Twig_Node_Expression_Function $functionNode, $minNum /*, type [, type... ] */) {
+        $arguments = $this->getArguments($functionNode);
+        
+        if (count($arguments) < $minNum) {
+            throw new InvalidArgumentException(sprintf('Function %s expects at least %d arguments, found %d in %s on line %d',
+                                                       $functionNode->getAttribute('name'),
+                                                       $minNum,
+                                                       count($arguments),
+                                                       $this->file,
+                                                       $functionNode->getLine()));
+        }
+        
+        $types = func_get_args();
+        $types = array_slice($types, 2);
+        
+        if (count($types) < $minNum) {
+            throw new LogicException(sprintf('Minimum number of arguments given as %d, but only %d type validations supplied',
+                                             $minNum, count($types)));
+        }
+        
+        for ($i = 0; $i < $minNum; $i++) {
+            if ($types[$i] === null) {
+                continue;
+            }
+            if (!($arguments[$i] instanceof $types[$i])) {
+                throw new InvalidArgumentException(sprintf('Argument %d for %s must be of type %s, found %s in %s on line %d',
+                                                           $i + 1,
+                                                           $functionNode->getAttribute('name'),
+                                                           $types[$i],
+                                                           get_class($arguments[$i]),
+                                                           $this->file,
+                                                           $functionNode->getLine()));
+            }
+        }
+        
+        return $arguments;
+    }
+    
+    protected function pushEntry(Twig_Extensions_Extension_Gettext_POString_Interface $string, $line) {
+        if ($comment = $this->getPreceedingCommentNode($line)) {
+            $string->setExtractedComments(trim($comment->getValue()));
+        }
+        $string->addReference("$this->file:$line");
+        $this->strings[] = $string;
+    }
+    
+    protected function getPOString($msgid, $msgidPlural = null) {
+        return $this->POStringFactory->construct($msgid, $msgidPlural);
+    }
+    
+}

--- a/lib/Twig/Extensions/Extension/Gettext/Extractor.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Extractor.php
@@ -44,7 +44,8 @@ class Twig_Extensions_Extension_Gettext_Extractor {
     
     protected function extractComments(Twig_TokenStream $stream) {
         $tokens = array();
-        
+        $this->comments = array();
+
         while (!$stream->isEOF()) {
             $token = $stream->next();
             

--- a/lib/Twig/Extensions/Extension/Gettext/Extractor.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Extractor.php
@@ -25,11 +25,14 @@ class Twig_Extensions_Extension_Gettext_Extractor {
     
     /**
      * @param Twig_Extensions_Extension_Gettext_POString_Factory_Interface $POStringFactory An object for constructing POString objects.
+     * @param array $extensions Additional extensions that need to be loaded into the environment.
      */
-    public function __construct(Twig_Extensions_Extension_Gettext_POString_Factory_Interface $POStringFactory) {
+    public function __construct(Twig_Extensions_Extension_Gettext_POString_Factory_Interface $POStringFactory, array $extensions = array()) {
         $this->POStringFactory = $POStringFactory;
         
-        $twig         = new Twig_Environment(new Twig_Loader_String);
+        $twig = new Twig_Environment(new Twig_Loader_String);
+        array_map(array($twig, 'addExtension'), $extensions);
+        
         $this->lexer  = new Twig_Extensions_Extension_Gettext_Lexer($twig);
         $this->parser = new Twig_Parser($twig);
     }

--- a/lib/Twig/Extensions/Extension/Gettext/Extractor.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Extractor.php
@@ -2,6 +2,13 @@
 
 class Twig_Extensions_Extension_Gettext_Extractor {
     
+    const VARIABLE     = 0;
+    const MSGID        = 'msgid';
+    const MSGID_PLURAL = 'msgid_plural';
+    const DOMAIN       = 'domain';
+    const CATEGORY     = 'category';
+    const CONTEXT      = 'context';
+    
     protected $strings = array();
     
     protected $comments = array();
@@ -77,9 +84,15 @@ class Twig_Extensions_Extension_Gettext_Extractor {
     }
     
     protected function processNode(Twig_NodeInterface $node) {
-        if ($node instanceof Twig_Node_Expression_Function) {
-            $this->processFunctionNode($node);
+        switch (true) {
+            case $node instanceof Twig_Node_Expression_Function :
+                $this->processFunctionNode($node);
+                break;
+            case $node instanceof Twig_Node_Expression_Filter :
+                $this->processFilterNode($node);
+                break;
         }
+        
     
         foreach ($node as $child) {
             if ($child instanceof Twig_NodeInterface) {
@@ -92,224 +105,196 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         switch ($node->getAttribute('name')) {
             case '_' :
             case 'gettext' :
-            case '_f' :
-            case 'fgettext' :
-                $this->gettext($node);
+                $this->pushFunction($node, self::MSGID);
                 break;
             case '_p' :
             case 'pgettext' :
-            case '_pf' :
-            case 'pfgettext' :
-                $this->pgettext($node);
+                $this->pushFunction($node, self::CONTEXT, self::MSGID);
                 break;
             case '_n' :
             case 'ngettext' :
-            case '_nf' :
-            case 'nfgettext' :
-                $this->ngettext($node);
+                $this->pushFunction($node, self::MSGID, self::MSGID_PLURAL, self::VARIABLE);
                 break;
             case '_np' :
             case 'npgettext' :
-            case '_npf' :
-            case 'npfgettext' :
-                $this->npgettext($node);
+                $this->pushFunction($node, self::CONTEXT, self::MSGID, self::MSGID_PLURAL, self::VARIABLE);
                 break;
             case '_d' :
             case 'dgettext' :
-            case '_df' :
-            case 'dfgettext' :
-                $this->dgettext($node);
+                $this->pushFunction($node, self::DOMAIN, self::MSGID);
                 break;
             case '_dp' :
             case 'dpgettext' :
-            case '_dpf' :
-            case 'dpfgettext' :
-                $this->dpgettext($node);
+                $this->pushFunction($node, self::CONTEXT, self::DOMAIN, self::MSGID);
                 break;
             case '_dn' :
             case 'dngettext' :
-            case '_dnf' :
-            case 'dnfgettext' :
-                $this->dngettext($node);
+                $this->pushFunction($node, self::DOMAIN, self::MSGID, self::MSGID_PLURAL, self::VARIABLE);
                 break;
             case '_dnp' :
             case 'dnpgettext' :
-            case '_dnpf' :
-            case 'dnpfgettext' :
-                $this->dnpgettext($node);
+                $this->pushFunction($node, self::CONTEXT, self::DOMAIN, self::MSGID, self::MSGID_PLURAL, self::VARIABLE);
                 break;
             case '_dc' :
             case 'dcgettext' :
-            case '_dcf' :
-            case 'dcfgettext' :
-                $this->dcgettext($node);
+                $this->pushFunction($node, self::DOMAIN, self::MSGID, self::CATEGORY);
                 break;
             case '_dcp' :
             case 'dcpgettext' :
-            case '_dcpf' :
-            case 'dcpfgettext' :
-                $this->dcpgettext($node);
+                $this->pushFunction($node, self::CONTEXT, self::DOMAIN, self::MSGID, self::CATEGORY);
                 break;
             case '_dcn' :
             case 'dcngettext' :
-            case '_dcnf' :
-            case 'dcnfgettext' :
-                $this->dcngettext($node);
+                $this->pushFunction($node, self::DOMAIN, self::MSGID, self::MSGID_PLURAL, self::VARIABLE, self::CATEGORY);
                 break;
             case '_dcnp' :
             case 'dcnpgettext' :
-            case '_dcnpf' :
-            case 'dcnpfgettext' :
-                $this->dcnpgettext($node);
+                $this->pushFunction($node, self::CONTEXT, self::DOMAIN, self::MSGID, self::MSGID_PLURAL, self::VARIABLE, self::CATEGORY);
                 break;
         }
     }
     
-    protected function gettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 1, 'Twig_Node_Expression_Constant');
-        $this->pushEntry($this->getPOString($arguments[0]->getAttribute('value')), $node->getLine());
-    }
-    
-    protected function pgettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 2, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
-        $string = $this->getPOString($arguments[1]->getAttribute('value'));
-        $string->setMsgctxt($arguments[0]->getAttribute('value'));
-        $this->pushEntry($string, $node->getLine());
-    }
-        
-    protected function ngettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 3, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null);
-        $string = $this->getPOString($arguments[0]->getAttribute('value'), $arguments[1]->getAttribute('value'));
-        $this->pushEntry($string, $node->getLine());
-    }
-        
-    protected function npgettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 4, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null);
-        $string = $this->getPOString($arguments[1]->getAttribute('value'), $arguments[2]->getAttribute('value'));
-        $string->setMsgctxt($arguments[0]->getAttribute('value'));
-        $this->pushEntry($string, $node->getLine());
-    }
-        
-    protected function dgettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 2, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
-        $string = $this->getPOString($arguments[1]->getAttribute('value'));
-        $string->setDomain($arguments[0]->getAttribute('value'));
-        $this->pushEntry($string, $node->getLine());
-    }
-        
-    protected function dpgettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 3, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
-        $string = $this->getPOString($arguments[2]->getAttribute('value'));
-        $string->setMsgctxt($arguments[1]->getAttribute('value'));
-        $string->setDomain($arguments[0]->getAttribute('value'));
-        $this->pushEntry($string, $node->getLine());
-    }
-        
-    protected function dngettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 4, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null);
-        $string = $this->getPOString($arguments[1]->getAttribute('value'), $arguments[2]->getAttribute('value'));
-        $string->setDomain($arguments[0]->getAttribute('value'));
-        $this->pushEntry($string, $node->getLine());
-    }
-    
-    protected function dnpgettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 5, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null);
-        $string = $this->getPOString($arguments[2]->getAttribute('value'), $arguments[3]->getAttribute('value'));
-        $string->setDomain($arguments[0]->getAttribute('value'));
-        $string->setMsgctxt($arguments[1]->getAttribute('value'));
-        $this->pushEntry($string, $node->getLine());
-    }
-    
-    protected function dcgettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 3, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
-        $string = $this->getPOString($arguments[1]->getAttribute('value'));
-        $string->setDomain($arguments[0]->getAttribute('value'));
-        $string->setCategory(constant($arguments[2]->getAttribute('value')));
-        $this->pushEntry($string, $node->getLine());
-    }
-    
-    protected function dcpgettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 4, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant');
-        $string = $this->getPOString($arguments[1]->getAttribute('value'));
-        $string->setDomain($arguments[0]->getAttribute('value'));
-        $string->setMsgctxt($arguments[1]->getAttribute('value'));
-        $string->setCategory(constant($arguments[3]->getAttribute('value')));
-        $this->pushEntry($string, $node->getLine());
-    }
-    
-    protected function dcngettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 5, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null, 'Twig_Node_Expression_Constant');
-        $string = $this->getPOString($arguments[1]->getAttribute('value'), $arguments[2]->getAttribute('value'));
-        $string->setDomain($arguments[0]->getAttribute('value'));
-        $string->setCategory(constant($arguments[4]->getAttribute('value')));
-        $this->pushEntry($string, $node->getLine());
-    }
-    
-    protected function dcnpgettext(Twig_Node_Expression_Function $node) {
-        $arguments = $this->validateArguments($node, 6, 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', 'Twig_Node_Expression_Constant', null, 'Twig_Node_Expression_Constant');
-        $string = $this->getPOString($arguments[2]->getAttribute('value'), $arguments[3]->getAttribute('value'));
-        $string->setDomain($arguments[0]->getAttribute('value'));
-        $string->setMsgctxt($arguments[1]->getAttribute('value'));
-        $string->setCategory(constant($arguments[5]->getAttribute('value')));
-        $this->pushEntry($string, $node->getLine());
-    }
-        
-    protected function getArguments(Twig_Node_Expression_Function $functionNode) {
-        $arguments = array();
-        foreach ($functionNode->getNode('arguments') as $argument) {
-            $arguments[] = $argument;
+    protected function processFilterNode(Twig_Node_Expression_Filter $node) {
+        switch ($node->getNode('filter')->getAttribute('value')) {
+            case '_' :
+            case 'gettext' :
+                $this->pushFilter($node);
+                break;
+            case '_p' :
+            case 'pgettext' :
+                $this->pushFilter($node, self::CONTEXT);
+                break;
+            case '_n' :
+            case 'ngettext' :
+                $this->pushFilter($node, self::MSGID_PLURAL);
+                break;
+            case '_np' :
+            case 'npgettext' :
+                $this->pushFilter($node, self::MSGID_PLURAL, self::VARIABLE, self::CONTEXT);
+                break;
+            case '_d' :
+            case 'dgettext' :
+                $this->pushFilter($node, self::DOMAIN);
+                break;
+            case '_dp' :
+            case 'dpgettext' :
+                $this->pushFilter($node, self::DOMAIN, self::CONTEXT);
+                break;
+            case '_dn' :
+            case 'dngettext' :
+                $this->pushFilter($node, self::MSGID_PLURAL, self::VARIABLE, self::DOMAIN);
+                break;
+            case '_dnp' :
+            case 'dnpgettext' :
+                $this->pushFilter($node, self::MSGID_PLURAL, self::VARIABLE, self::DOMAIN, self::CONTEXT);
+                break;
+            case '_dc' :
+            case 'dcgettext' :
+                $this->pushFilter($node, self::DOMAIN, self::CATEGORY);
+                break;
+            case '_dcp' :
+            case 'dcpgettext' :
+                $this->pushFilter($node, self::DOMAIN, self::CATEGORY, self::CONTEXT);
+                break;
+            case '_dcn' :
+            case 'dcngettext' :
+                $this->pushFilter($node, self::MSGID_PLURAL, self::VARIABLE, self::DOMAIN, self::CATEGORY);
+                break;
+            case '_dcnp' :
+            case 'dcnpgettext' :
+                $this->pushFilter($node, self::MSGID_PLURAL, self::VARIABLE, self::DOMAIN, self::CATEGORY, self::CONTEXT);
+                break;
         }
-        return $arguments;
     }
     
-    protected function validateArguments(Twig_Node_Expression_Function $functionNode, $minNum /*, type [, type... ] */) {
-        $arguments = $this->getArguments($functionNode);
+    protected function pushFunction(Twig_Node_Expression_Function $node /*, arg, .. */) {
+        $args = func_get_args();
+        array_shift($args);
+
+        $valueNodes = array();
         
-        if (count($arguments) < $minNum) {
-            throw new InvalidArgumentException(sprintf('Function %s expects at least %d arguments, found %d in %s on line %d',
-                                                       $functionNode->getAttribute('name'),
-                                                       $minNum,
-                                                       count($arguments),
-                                                       $this->file,
-                                                       $functionNode->getLine()));
+        foreach ($node->getNode('arguments') as $i => $argumentNode) {
+            if (!isset($args[$i])) {
+                break;
+            }
+            $valueNodes[$args[$i]] = $argumentNode;
         }
         
-        $types = func_get_args();
-        $types = array_slice($types, 2);
+        $this->pushEntry($node, $valueNodes);
+    }
+    
+    protected function pushFilter(Twig_Node_Expression_Filter $node /*, arg, .. */) {
+        $args = func_get_args();
+        array_shift($args);
         
-        if (count($types) < $minNum) {
-            throw new LogicException(sprintf('Minimum number of arguments given as %d, but only %d type validations supplied',
-                                             $minNum, count($types)));
+        $valueNodes = array(self::MSGID => $node->getNode('node'));
+        
+        foreach ($node->getNode('arguments') as $i => $argumentNode) {
+            if (!isset($args[$i])) {
+                break;
+            }
+            $valueNodes[$args[$i]] = $argumentNode;
         }
         
-        for ($i = 0; $i < $minNum; $i++) {
-            if ($types[$i] === null) {
+        $this->pushEntry($node, $valueNodes);
+    }
+    
+    protected function pushEntry(Twig_Node_Expression $node, array $valueNodes) {
+        if (!isset($valueNodes[self::MSGID])) {
+            throw new LogicException('$valueNodes array must contain a MSGID value');
+        }
+        
+        $POString = $this->POStringFactory->construct($valueNodes[self::MSGID]->getAttribute('value'));
+        
+        foreach ($valueNodes as $type => $argument) {
+            if ($type === self::VARIABLE) {
                 continue;
+            } else if (!($argument instanceof Twig_Node_Expression_Constant)) {
+                $this->invalidArgumentTypeParseError($argument, $node);
             }
-            if (!($arguments[$i] instanceof $types[$i])) {
-                throw new InvalidArgumentException(sprintf('Argument %d for %s must be of type %s, found %s in %s on line %d',
-                                                           $i + 1,
-                                                           $functionNode->getAttribute('name'),
-                                                           $types[$i],
-                                                           get_class($arguments[$i]),
-                                                           $this->file,
-                                                           $functionNode->getLine()));
+            
+            switch ($type) {
+                case self::MSGID :
+                    continue;
+                case self::MSGID_PLURAL :
+                    $POString->setMsgidPlural($argument->getAttribute('value'));
+                    break;
+                case self::DOMAIN :
+                    $POString->setDomain($argument->getAttribute('value'));
+                    break;
+                case self::CATEGORY :
+                    $POString->setCategory($argument->getAttribute('value'));
+                    break;
+                case self::CONTEXT :
+                    $POString->setMsgctxt($argument->getAttribute('value'));
+                    break;
+                default :
+                    throw new InvalidArgumentException("Invalid argument '$type'");
             }
         }
         
-        return $arguments;
-    }
-    
-    protected function pushEntry(Twig_Extensions_Extension_Gettext_POString_Interface $string, $line) {
-        if ($comment = $this->getPreceedingCommentNode($line)) {
-            $string->setExtractedComments(trim($comment->getValue()));
+        if ($comment = $this->getPreceedingCommentNode($node->getLine())) {
+            $POString->setExtractedComments(trim($comment->getValue()));
         }
-        $string->addReference("$this->file:$line");
-        $this->strings[] = $string;
+        $POString->addReference(sprintf("$this->file:%d", $node->getLine()));
+        $this->strings[] = $POString;
     }
     
-    protected function getPOString($msgid, $msgidPlural = null) {
-        return $this->POStringFactory->construct($msgid, $msgidPlural);
+    protected function invalidArgumentTypeParseError(Twig_Node_Expression $argument, Twig_Node_Expression $node) {
+        switch (true) {
+            case $node instanceof Twig_Node_Expression_Function :
+                $name = $node->getAttribute('name');
+                break;
+            case $node instanceof Twig_Node_Expression_Filter :
+                $name = $node->getNode('filter')->getAttribute('value');
+                break;
+            default :
+                throw new LogicException(sprintf("Don't know how to get name of node %s to throw an InvalidArgumentException",
+                                                 get_class($node)));
+        }
+        
+        throw new InvalidArgumentException(sprintf('Invalid argument of type %s for %s in %s on line %d',
+                                                   get_class($argument), $name, $this->file, $node->getLine()));
     }
     
 }

--- a/lib/Twig/Extensions/Extension/Gettext/Extractor.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Extractor.php
@@ -21,6 +21,9 @@ class Twig_Extensions_Extension_Gettext_Extractor {
     
     protected $POStringFactory;
     
+    /**
+     * @param Twig_Extensions_Extension_Gettext_POString_Factory_Interface $POStringFactory An object for constructing POString objects.
+     */
     public function __construct(Twig_Extensions_Extension_Gettext_POString_Factory_Interface $POStringFactory) {
         $this->POStringFactory = $POStringFactory;
         
@@ -29,6 +32,12 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         $this->parser = new Twig_Parser($twig);
     }
     
+    /**
+     * Extracts all gettext strings from given Twig template file.
+     * 
+     * @param string $file Path to Twig template file.
+     * @return array Array of POString objects.
+     */
     public function extractFile($file) {
         $this->strings = array();
         $this->file    = $file;
@@ -42,6 +51,12 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         return $this->strings;
     }
     
+    /**
+     * Returns comment node immediately preceeding given line number, if any.
+     * 
+     * @param int $lineno
+     * @return Twig_Extensions_Extension_Gettext_Token Closest preceeding comment token or null.
+     */
     protected function getPreceedingCommentNode($lineno) {
         $commentNode = null;
         foreach ($this->comments as $comment) {
@@ -63,6 +78,11 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         return $commentNode;
     }
     
+    /**
+     * Processes a node and its child nodes recursively.
+     * 
+     * @param Twig_NodeInterface $node
+     */
     protected function processNode(Twig_NodeInterface $node) {
         switch (true) {
             case $node instanceof Twig_Node_Expression_Function :
@@ -81,6 +101,11 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         }
     }
     
+    /**
+     * Processes a Function node.
+     * 
+     * @param Twig_Node_Expression_Function $node
+     */
     protected function processFunctionNode(Twig_Node_Expression_Function $node) {
         switch ($node->getAttribute('name')) {
             case '_' :
@@ -134,6 +159,11 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         }
     }
     
+    /**
+     * Processes a Filter node.
+     * 
+     * @param Twig_Node_Expression_Filter $node
+     */
     protected function processFilterNode(Twig_Node_Expression_Filter $node) {
         switch ($node->getNode('filter')->getAttribute('value')) {
             case '_' :
@@ -187,6 +217,12 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         }
     }
     
+    /**
+     * Parses arguments of a Function node and pushes entry into list of extracted strings.
+     * 
+     * @param Twig_Node_Expression_Function $node
+     * @param mixed Variable number of arguments representing roles of the Twig function arguments.
+     */
     protected function pushFunction(Twig_Node_Expression_Function $node /*, arg, .. */) {
         $args = func_get_args();
         array_shift($args);
@@ -203,6 +239,12 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         $this->pushEntry($node, $valueNodes);
     }
     
+    /**
+     * Parses arguments of a Filter node and pushes entry into list of extracted strings.
+     * 
+     * @param Twig_Node_Expression_Filter $node
+     * @param mixed Variable number of arguments representing roles of the Twig filter arguments.
+     */
     protected function pushFilter(Twig_Node_Expression_Filter $node /*, arg, .. */) {
         $args = func_get_args();
         array_shift($args);
@@ -219,6 +261,12 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         $this->pushEntry($node, $valueNodes);
     }
     
+    /**
+     * Pushes entry into list of extracted strings.
+     * 
+     * @param Twig_Node_Expression $node
+     * @param array $valueNodes Associative array of value nodes (values) and their role (keys).
+     */
     protected function pushEntry(Twig_Node_Expression $node, array $valueNodes) {
         if (!isset($valueNodes[self::MSGID])) {
             throw new LogicException('$valueNodes array must contain a MSGID value');
@@ -260,6 +308,14 @@ class Twig_Extensions_Extension_Gettext_Extractor {
         $this->strings[] = $POString;
     }
     
+    /**
+     * Throws an exception with detailled error message in case of argument parse errors.
+     * 
+     * @param Twig_Node_Expression $argument The invalid/unexpected argument node.
+     * @param Twig_Node_Expression $node The Filter or Function node to which the $argument belongs.
+     * @throws InvalidArgumentException (The main purpose.)
+     * @throws LogicException In case an unexpected $node argument was passed.
+     */
     protected function invalidArgumentTypeParseError(Twig_Node_Expression $argument, Twig_Node_Expression $node) {
         switch (true) {
             case $node instanceof Twig_Node_Expression_Function :

--- a/lib/Twig/Extensions/Extension/Gettext/Lexer.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Lexer.php
@@ -2,24 +2,36 @@
 
 class Twig_Extensions_Extension_Gettext_Lexer extends Twig_Lexer {
     
+    protected $commentTokens = array();
+    
+    /**
+     * Overrides tokenize to initialize $this->commentTokens.
+     */
+    public function tokenize($code, $filename = null) {
+        $this->commentTokens = array();
+        return parent::tokenize($code, $filename);
+    }
+    
+    /**
+     * Overrides lexComment by saving comment tokens into $this->commentTokens
+     * instead of just ignoring them.
+     */
     protected function lexComment() {
         if (!preg_match($this->regexes['lex_comment'], $this->code, $match, PREG_OFFSET_CAPTURE, $this->cursor)) {
             throw new Twig_Error_Syntax('Unclosed comment', $this->lineno, $this->filename);
         }
 
         $value = substr($this->code, $this->cursor, $match[0][1] - $this->cursor);
-        $this->pushToken(Twig_Extensions_Extension_Gettext_Token::COMMENT, $value);
+        $token = new Twig_Extensions_Extension_Gettext_Token(Twig_Extensions_Extension_Gettext_Token::COMMENT, $value, $this->lineno);
+        $this->commentTokens[] = $token;
         $this->moveCursor($value . $match[0][0]);
     }
     
-    protected function pushToken($type, $value = '') {
-        switch ($type) {
-            case Twig_Extensions_Extension_Gettext_Token::COMMENT :
-                $this->tokens[] = new Twig_Extensions_Extension_Gettext_Token($type, $value, $this->lineno);
-                break;
-            default :
-                parent::pushToken($type, $value);
-        }
+    /**
+     * Returns the comment tokens that were extracted.
+     */
+    public function getCommentTokens() {
+        return $this->commentTokens;
     }
     
 }

--- a/lib/Twig/Extensions/Extension/Gettext/Lexer.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Lexer.php
@@ -1,0 +1,25 @@
+<?php
+
+class Twig_Extensions_Extension_Gettext_Lexer extends Twig_Lexer {
+    
+    protected function lexComment() {
+        if (!preg_match($this->regexes['lex_comment'], $this->code, $match, PREG_OFFSET_CAPTURE, $this->cursor)) {
+            throw new Twig_Error_Syntax('Unclosed comment', $this->lineno, $this->filename);
+        }
+
+        $value = substr($this->code, $this->cursor, $match[0][1] - $this->cursor);
+        $this->pushToken(Twig_Extensions_Extension_Gettext_Token::COMMENT, $value);
+        $this->moveCursor($value . $match[0][0]);
+    }
+    
+    protected function pushToken($type, $value = '') {
+        switch ($type) {
+            case Twig_Extensions_Extension_Gettext_Token::COMMENT :
+                $this->tokens[] = new Twig_Extensions_Extension_Gettext_Token($type, $value, $this->lineno);
+                break;
+            default :
+                parent::pushToken($type, $value);
+        }
+    }
+    
+}

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Factory/Interface.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Factory/Interface.php
@@ -2,6 +2,10 @@
 
 interface Twig_Extensions_Extension_Gettext_POString_Factory_Interface {
     
-    public function construct($msgid, $msgidPlural = null);
+    /**
+     * @param string $msgid The singular extracted string.
+     * @return Twig_Extensions_Extension_Gettext_POString_Interface
+     */
+    public function construct($msgid);
     
 }

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Factory/Interface.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Factory/Interface.php
@@ -1,0 +1,7 @@
+<?php
+
+interface Twig_Extensions_Extension_Gettext_POString_Factory_Interface {
+    
+    public function construct($msgid, $msgidPlural = null);
+    
+}

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Interface.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Interface.php
@@ -2,20 +2,52 @@
 
 interface Twig_Extensions_Extension_Gettext_POString_Interface {
     
+    /**
+     * @param string $msgid The primary localizable string.
+     */
     public function __construct($msgid);
 
+    /**
+     * @param string $msgidPlural The pluralized string (for ngettext and similar).
+     */
     public function setMsgidPlural($msgidPlural);
 
+    /**
+     * @param int $category The category, i.e. one of the LC_* constants.
+     */
     public function setCategory($category);
     
+    /**
+     * @param string $domain The domain (for dgettext and similar).
+     */
     public function setDomain($domain);
     
+    /**
+     * @param string $msgctxt The context (for pgettext and similar).
+     */
     public function setMsgctxt($msgctxt);
     
+    /**
+     * Add a related source code comment. There may be more than one.
+     * 
+     * @param string $comment Arbitrary text. May contain xgettext flags, which this method may parse.
+     */
     public function addExtractedComment($comment);
     
+    /**
+     * Add a reference to a source code file and line number.
+     * There may be more than one.
+     * 
+     * @param string $reference Single line strings like "/path/to/file.twig:42"
+     */
     public function addReference($reference);
     
+    /**
+     * Add a flag. There may be more than one. The object should take care that mutually exclusive
+     * flags are treated as such, typically by unsetting previously set conflicting flags.
+     * 
+     * @param string $flag Flags like "php-format", "no-php-format", "range: 0..42" etc.
+     */
     public function addFlag($flag);
     
 }

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Interface.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Interface.php
@@ -2,7 +2,9 @@
 
 interface Twig_Extensions_Extension_Gettext_POString_Interface {
     
-    public function __construct($msgid, $msgidPlural = null);
+    public function __construct($msgid);
+
+    public function setMsgidPlural($msgidPlural);
 
     public function setCategory($category);
     

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Interface.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Interface.php
@@ -12,7 +12,7 @@ interface Twig_Extensions_Extension_Gettext_POString_Interface {
     
     public function setMsgctxt($msgctxt);
     
-    public function setExtractedComment($comment);
+    public function addExtractedComment($comment);
     
     public function addReference($reference);
     

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Interface.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Interface.php
@@ -1,0 +1,19 @@
+<?php
+
+interface Twig_Extensions_Extension_Gettext_POString_Interface {
+    
+    public function __construct($msgid, $msgidPlural = null);
+
+    public function setCategory($category);
+    
+    public function setDomain($domain);
+    
+    public function setMsgctxt($msgctxt);
+    
+    public function setExtractedComment($comment);
+    
+    public function addReference($reference);
+    
+    public function addFlag($flag);
+    
+}

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Kunststube/Adapter.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Kunststube/Adapter.php
@@ -1,0 +1,5 @@
+<?php
+
+class Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter
+    extends Kunststube\POTools\POString
+    implements Twig_Extensions_Extension_Gettext_POString_Interface { }

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Kunststube/Adapter.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Kunststube/Adapter.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * An adapter to use the Kunststube\POTools\POString object as
+ * POString object for Twig_Extensions_Extension_Gettext_Extractor.
+ * See https://github.com/deceze/Kunststube-POTools.
+ */
 class Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter
     extends Kunststube\POTools\POString
-    implements Twig_Extensions_Extension_Gettext_POString_Interface { }
+    implements Twig_Extensions_Extension_Gettext_POString_Interface {
+        
+    public function __construct($msgid) {
+        parent::__construct($msgid);
+    }
+        
+}

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Kunststube/Adapter/Factory.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Kunststube/Adapter/Factory.php
@@ -1,0 +1,10 @@
+<?php
+
+class Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter_Factory
+    implements Twig_Extensions_Extension_Gettext_POString_Factory_Interface {
+    
+    public function construct($msgid, $msgidPlural = null) {
+        return new Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter($msgid, $msgidPlural);
+    }
+    
+}

--- a/lib/Twig/Extensions/Extension/Gettext/POString/Kunststube/Adapter/Factory.php
+++ b/lib/Twig/Extensions/Extension/Gettext/POString/Kunststube/Adapter/Factory.php
@@ -1,10 +1,13 @@
 <?php
 
+/**
+ * A factory for Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter objects.
+ */
 class Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter_Factory
     implements Twig_Extensions_Extension_Gettext_POString_Factory_Interface {
     
-    public function construct($msgid, $msgidPlural = null) {
-        return new Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter($msgid, $msgidPlural);
+    public function construct($msgid) {
+        return new Twig_Extensions_Extension_Gettext_POString_Kunststube_Adapter($msgid);
     }
     
 }

--- a/lib/Twig/Extensions/Extension/Gettext/Token.php
+++ b/lib/Twig/Extensions/Extension/Gettext/Token.php
@@ -1,0 +1,28 @@
+<?php
+
+class Twig_Extensions_Extension_Gettext_Token extends Twig_Token {
+    
+    const COMMENT = 12;
+    
+    public static function typeToString($type, $short = false, $line = -1) {
+        switch ($type) {
+            case self::COMMENT :
+                $name = 'COMMENT';
+                break;
+            default :
+                return parent::typeToString($type, $short, $line);
+        }
+
+        return $short ? $name : 'Twig_Token::'.$name;
+    }
+
+    public static function typeToEnglish($type, $line = -1) {
+        switch ($type) {
+            case self::COMMENT :
+                return 'comment';
+            default :
+                return parent::typeToEnglish($type, $line);
+        }
+    }
+
+}


### PR DESCRIPTION
As suggested in issue #75, the gettext integration through the i18n extension is very limited. I have added a new Gettext extension, which provides all the bells and whistles of the gettext library. Please see the updated docs for a full rundown of usage and features.

The extractor is implemented with the native `Twig_Lexer` and `Twig_Parser`, but extends the Lexer and Token classes in order to preserve and extract comment nodes. This is arguably somewhat hackie and it produces extra files in the `Extensions/Extension/Gettext` folder, please advise if there's a better way to organize this or hook into the whole process.

I have published the tools for writing POT files at https://github.com/deceze/Kunststube-POTools and have included an adapter here. I have done so since these tools have a use beyond Twig and bundling them into Twig seems inappropriate. It also allows users to hook in a different toolchain if desired. Please advise if you have specific requirements for such bundling/external libraries.

I just wonder in how far the existing i18n extension should be replaced by/merged into this.
