### PR TITLE
removed unnecessary locale check

### DIFF
--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -54,7 +54,7 @@ function twig_localized_date_filter(Twig_Environment $env, $date, $dateFormat = 
     );
 
     $formatter = IntlDateFormatter::create(
-        $locale !== null ? $locale : Locale::getDefault(),
+        $locale,
         $formatValues[$dateFormat],
         $formatValues[$timeFormat],
         $date->getTimezone()->getName(),


### PR DESCRIPTION
If $locale === NULL, the default locale is used. See the php-src: https://github.com/php/php-src/blob/master/ext/intl/formatter/formatter_main.c#L58-L60
