### PR TITLE
Removes nl2br from the text documentation

### DIFF
--- a/doc/text.rst
+++ b/doc/text.rst
@@ -5,7 +5,6 @@ The Text extension provides the following filters:
 
 * ``truncate``
 * ``wordwrap``
-* ``nl2br``
 
 Installation
 ------------


### PR DESCRIPTION
The documentation for the text extensions still refers to the
nl2br tag, which has been removed from extensions and added to
the main Twig repo. This commit removes the mention of nl2br
from this repo.
