### PR TITLE
Array extension: add the 'sum' filter

### DIFF
--- a/doc/array.rst
+++ b/doc/array.rst
@@ -4,6 +4,7 @@ The Array Extension
 The Array extensions provides the following filters:
 
 * ``shuffle``
+* ``sum``
 
 Installation
 ------------

--- a/lib/Twig/Extensions/Extension/Array.php
+++ b/lib/Twig/Extensions/Extension/Array.php
@@ -23,6 +23,7 @@ class Twig_Extensions_Extension_Array extends Twig_Extension
     {
         $filters = array(
              new Twig_SimpleFilter('shuffle', 'twig_shuffle_filter'),
+             new Twig_SimpleFilter('sum', 'twig_sum_filter'),
         );
 
         return $filters;
@@ -53,4 +54,19 @@ function twig_shuffle_filter($array)
     shuffle($array);
 
     return $array;
+}
+
+/**
+ * Calculate the sum of values in an array.
+ *
+ * @param array|Traversable $array An array
+ * @return number
+ */
+function twig_sum_filter($array)
+{
+    if ($array instanceof Traversable) {
+        $array = iterator_to_array($array, false);
+    }
+
+    return array_sum($array);
 }

--- a/test/Twig/Tests/Extension/ArrayTest.php
+++ b/test/Twig/Tests/Extension/ArrayTest.php
@@ -44,4 +44,25 @@ class Twig_Tests_Extension_ArrayTest extends PHPUnit_Framework_TestCase
             ),
         );
     }
+
+    /**
+     * @dataProvider getSumFilterTestData
+     */
+    public function testSumFilter($expectedSum, $array)
+    {
+        $this->assertEquals($expectedSum, twig_sum_filter($array));
+    }
+
+    public function getSumFilterTestData()
+    {
+        return array(
+            array(6,    array(1, 2, 3)),
+            array(3.14, array(0, 1, 0.5, 0.5, 1.14)),
+            array(6,    array("a" => 1, "b" => 2, 3)),
+            array(3.14, array("a" => 0, 1, "b" => 0.5, 0.5, "c" => 1.14)),
+            array(3.14, array(true, "1", "1.14")),
+            array(8,    array("a", 1, "b", 2, "c", 3, null, false, true, "1")),
+            array(0,    array())
+        );
+    }
 }


### PR DESCRIPTION
Add the `sum` filter based on `array_sum` php function.
Add unit tests.
Update doc.
