### PR TITLE
Fixed truncate filter from text extension

### DIFF
--- a/lib/Twig/Extensions/Extension/Text.php
+++ b/lib/Twig/Extensions/Extension/Text.php
@@ -39,22 +39,21 @@ class Twig_Extensions_Extension_Text extends Twig_Extension
 }
 
 if (function_exists('mb_get_info')) {
-    function twig_truncate_filter(Twig_Environment $env, $value, $length = 30, $preserve = false, $separator = '...')
+    function twig_truncate_filter(Twig_Environment $env, $input, $limit = 30, $preserve = false, $separator = '...')
     {
-        if (mb_strlen($value, $env->getCharset()) > $length) {
-            if ($preserve) {
-                // If breakpoint is on the last word, return the value without separator.
-                if (false === ($breakpoint = mb_strpos($value, ' ', $length, $env->getCharset()))) {
-                    return $value;
-                }
-
-                $length = $breakpoint;
-            }
-
-            return rtrim(mb_substr($value, 0, $length, $env->getCharset())) . $separator;
+        $charset = $env->getCharset();
+        if (mb_strlen($input, $charset) <= $limit) {
+            return $input;
         }
+        $cutLength = $limit - mb_strlen($separator);
+        $firstCut = rtrim(mb_substr($input, 0, $cutLength, $charset));
+        $isBreakpointInWord = ($input[$cutLength] !== ' ');
+        if (!$preserve || !$isBreakpointInWord) {
+            return $firstCut.$separator;
+        }
+        $lastSpace = mb_strrpos($firstCut, ' ', 0, $charset);
 
-        return $value;
+        return rtrim(mb_substr($firstCut, 0, $lastSpace, $charset)).$separator;
     }
 
     function twig_wordwrap_filter(Twig_Environment $env, $value, $length = 80, $separator = "\n", $preserve = false)
@@ -79,19 +78,21 @@ if (function_exists('mb_get_info')) {
         return implode($separator, $sentences);
     }
 } else {
-    function twig_truncate_filter(Twig_Environment $env, $value, $length = 30, $preserve = false, $separator = '...')
+    function twig_truncate_filter(Twig_Environment $env, $input, $limit = 30, $preserve = false, $separator = '...')
     {
-        if (strlen($value) > $length) {
-            if ($preserve) {
-                if (false !== ($breakpoint = strpos($value, ' ', $length))) {
-                    $length = $breakpoint;
-                }
-            }
-
-            return rtrim(substr($value, 0, $length)) . $separator;
+        $charset = $env->getCharset();
+        if (strlen($input, $charset) <= $limit) {
+            return $input;
         }
+        $cutLength = $limit - strlen($separator);
+        $firstCut = rtrim(substr($input, 0, $cutLength, $charset));
+        $isBreakpointInWord = ($input[$cutLength] !== ' ');
+        if (!$preserve || !$isBreakpointInWord) {
+            return $firstCut.$separator;
+        }
+        $lastSpace = strrpos($firstCut, ' ', 0, $charset);
 
-        return $value;
+        return rtrim(substr($firstCut, 0, $lastSpace, $charset)).$separator;
     }
 
     function twig_wordwrap_filter(Twig_Environment $env, $value, $length = 80, $separator = "\n", $preserve = false)

--- a/lib/Twig/Extensions/Extension/Text.php
+++ b/lib/Twig/Extensions/Extension/Text.php
@@ -39,15 +39,15 @@ class Twig_Extensions_Extension_Text extends Twig_Extension
 }
 
 if (function_exists('mb_get_info')) {
-    function twig_truncate_filter(Twig_Environment $env, $input, $limit = 30, $preserve = false, $separator = '...')
+    function twig_truncate_filter(Twig_Environment $env, $value, $length = 30, $preserve = false, $separator = '...')
     {
         $charset = $env->getCharset();
-        if (mb_strlen($input, $charset) <= $limit) {
-            return $input;
+        if (mb_strlen($value, $charset) <= $length) {
+            return $value;
         }
-        $cutLength = $limit - mb_strlen($separator);
-        $firstCut = rtrim(mb_substr($input, 0, $cutLength, $charset));
-        $isBreakpointInWord = ($input[$cutLength] !== ' ');
+        $cutLength = $length - mb_strlen($separator);
+        $firstCut = rtrim(mb_substr($value, 0, $cutLength, $charset));
+        $isBreakpointInWord = ($value[$cutLength] !== ' ');
         if (!$preserve || !$isBreakpointInWord) {
             return $firstCut.$separator;
         }
@@ -78,15 +78,15 @@ if (function_exists('mb_get_info')) {
         return implode($separator, $sentences);
     }
 } else {
-    function twig_truncate_filter(Twig_Environment $env, $input, $limit = 30, $preserve = false, $separator = '...')
+    function twig_truncate_filter(Twig_Environment $env, $value, $length = 30, $preserve = false, $separator = '...')
     {
         $charset = $env->getCharset();
-        if (strlen($input, $charset) <= $limit) {
-            return $input;
+        if (strlen($value, $charset) <= $length) {
+            return $value;
         }
-        $cutLength = $limit - strlen($separator);
-        $firstCut = rtrim(substr($input, 0, $cutLength, $charset));
-        $isBreakpointInWord = ($input[$cutLength] !== ' ');
+        $cutLength = $length - strlen($separator);
+        $firstCut = rtrim(substr($value, 0, $cutLength, $charset));
+        $isBreakpointInWord = ($value[$cutLength] !== ' ');
         if (!$preserve || !$isBreakpointInWord) {
             return $firstCut.$separator;
         }

--- a/lib/Twig/Extensions/Extension/Text.php
+++ b/lib/Twig/Extensions/Extension/Text.php
@@ -67,7 +67,7 @@ if (function_exists('mb_get_info')) {
         mb_regex_encoding($previous);
 
         foreach ($pieces as $piece) {
-            while(!$preserve && mb_strlen($piece, $env->getCharset()) > $length) {
+            while (!$preserve && mb_strlen($piece, $env->getCharset()) > $length) {
                 $sentences[] = mb_substr($piece, 0, $length, $env->getCharset());
                 $piece = mb_substr($piece, $length, 2048, $env->getCharset());
             }

--- a/test/Twig/Tests/Extension/TextTest.php
+++ b/test/Twig/Tests/Extension/TextTest.php
@@ -97,7 +97,7 @@ class Twig_Tests_Extension_TextTest extends PHPUnit_Framework_TestCase
     public function testDoesNotPreservesWordWhenNoRoomLeft()
     {
         $input = 'No one expects the spanish inquisition';
-        $output ='No one expects the…';
+        $output = 'No one expects the…';
         $limit = mb_strlen($output);
 
         $actual = twig_truncate_filter($this->env, $input, $limit, true, '…');

--- a/test/Twig/Tests/Extension/TextTest.php
+++ b/test/Twig/Tests/Extension/TextTest.php
@@ -30,24 +30,77 @@ class Twig_Tests_Extension_TextTest extends PHPUnit_Framework_TestCase
         ;
     }
 
-    /**
-     * @dataProvider getTruncateTestData
-     */
-    public function testTruncate($input, $length, $preserve, $separator, $expectedOutput)
+    public function testDoesNotTruncateInputShorterThanLimit()
     {
-        $output = twig_truncate_filter($this->env, $input, $length, $preserve, $separator);
-        $this->assertEquals($expectedOutput, $output);
+        $input = 'We are the knights who say Ni!';
+        $output = 'We are the knights who say Ni!';
+        $limit = strlen($input) + 42;
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, false, '…');
+        $this->assertSame($output, $actual);
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, true, '…');
+        $this->assertSame($output, $actual);
     }
 
-    public function getTruncateTestData()
+    public function testDoesNotTruncateInputEqualToLimit()
     {
-        return array(
-            array('This is a very long sentence.', 2, false, '...', 'Th...'),
-            array('This is a very long sentence.', 6, false, '...', 'This i...'),
-            array('This is a very long sentence.', 2, true, '...', 'This...'),
-            array('This is a very long sentence.', 2, true, '[...]', 'This[...]'),
-            array('This is a very long sentence.', 23, false, '...', 'This is a very long sen...'),
-            array('This is a very long sentence.', 23, true, '...', 'This is a very long sentence.'),
-        );
+        $input = 'We are the knights who say Ni!';
+        $output = 'We are the knights who say Ni!';
+        $limit = strlen($input);
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, false, '…');
+        $this->assertSame($output, $actual);
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, true, '…');
+        $this->assertSame($output, $actual);
+    }
+
+    public function testTruncatesInputWayLargerThanLimit()
+    {
+        $input = 'Nobody expects the spanish inquisition';
+        $outputUnpreserved = 'Nobody expects the span…';
+        $outputPreserved = 'Nobody expects the…';
+        $limit = mb_strlen($outputUnpreserved);
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, false, '…');
+        $this->assertSame($outputUnpreserved, $actual);
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, true, '…');
+        $this->assertSame($outputPreserved, $actual);
+    }
+
+    public function testTruncatesInputOneCharacterLargerThanLimit()
+    {
+        $input = 'Nobody expects the spanish inquisition';
+        $outputUnpreserved = 'Nobody expects the spanish inquisi…';
+        $outputPreserved = 'Nobody expects the spanish…';
+        $limit = strlen($input) - 1;
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, false, '…');
+        $this->assertSame($outputUnpreserved, $actual);
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, true, '…');
+        $this->assertSame($outputPreserved, $actual);
+    }
+
+    public function testPreservesWordWhenRoomLeft()
+    {
+        $input = 'We are no longer the knights who say ni, we are now the knights...';
+        $output = 'We are no longer the knights who say ni, we…';
+        $limit = mb_strlen($output);
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, true, '…');
+        $this->assertSame($output, $actual);
+    }
+
+    public function testDoesNotPreservesWordWhenNoRoomLeft()
+    {
+        $input = 'No one expects the spanish inquisition';
+        $output ='No one expects the…';
+        $limit = mb_strlen($output);
+
+        $actual = twig_truncate_filter($this->env, $input, $limit, true, '…');
+        $this->assertSame($output, $actual);
     }
 }


### PR DESCRIPTION
When truncating, we want the text to be shorter than the given limit.
Previously, when asking to preserve words, the truncate filter would return text larger.

Example:

* input:` 'No one expects the spanish inquisition'|truncate(21, true, '…')`
* output: `'No one expects the spanish…'`
* expected: `'No one expects the…'`