### PR TITLE
Allow calculation of number precision

### DIFF
--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -80,9 +80,12 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
     $formatter = twig_get_number_formatter($locale, $style);
 
     if ($calculatePrecision) {
+
         $decimal = substr($number, strpos($number, '.')+1);
-        if ($decimal > $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS)) {
-            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, strlen($decimal));
+        $numberOfDecimals = strlen($decimal);
+
+        if ($decimal > 0 && $numberOfDecimals > $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS)) {
+            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, $numberOfDecimals);
         }
     }
 
@@ -98,9 +101,12 @@ function twig_localized_currency_filter($number, $currency = null, $locale = nul
     $formatter = twig_get_number_formatter($locale, 'currency');
 
     if ($calculatePrecision) {
+
         $decimal = substr($number, strpos($number, '.')+1);
-        if ($decimal > $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS)) {
-            $formatter->setAttribute(NumberFormatter::SIGNIFICANT_DIGITS_USED, strlen($decimal));
+        $numberOfDecimals = strlen($decimal);
+
+        if ($decimal > 0 && $numberOfDecimals > $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS)) {
+            $formatter->setAttribute(NumberFormatter::SIGNIFICANT_DIGITS_USED, $numberOfDecimals);
         }
     }
 

--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -67,7 +67,7 @@ function twig_localized_date_filter(Twig_Environment $env, $date, $dateFormat = 
     return $formatter->format($date->getTimestamp());
 }
 
-function twig_localized_number_filter($number, $style = 'decimal', $type = 'default', $locale = null)
+function twig_localized_number_filter($number, $style = 'decimal', $type = 'default', $locale = null, $calculatePrecision=false)
 {
     static $typeValues = array(
         'default'   => NumberFormatter::TYPE_DEFAULT,
@@ -79,6 +79,13 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
 
     $formatter = twig_get_number_formatter($locale, $style);
 
+    if ($calculatePrecision) {
+        $decimal = substr($number, strpos($number, '.')+1);
+        if ($decimal > $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS)) {
+            $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, strlen($decimal));
+        }
+    }
+
     if (!isset($typeValues[$type])) {
         throw new Twig_Error_Syntax(sprintf('The type "%s" does not exist. Known types are: "%s"', $type, implode('", "', array_keys($typeValues))));
     }
@@ -86,9 +93,16 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
     return $formatter->format($number, $typeValues[$type]);
 }
 
-function twig_localized_currency_filter($number, $currency = null, $locale = null)
+function twig_localized_currency_filter($number, $currency = null, $locale = null, $calculatePrecision=false)
 {
     $formatter = twig_get_number_formatter($locale, 'currency');
+
+    if ($calculatePrecision) {
+        $decimal = substr($number, strpos($number, '.')+1);
+        if ($decimal > $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS)) {
+            $formatter->setAttribute(NumberFormatter::SIGNIFICANT_DIGITS_USED, strlen($decimal));
+        }
+    }
 
     return $formatter->formatCurrency($number, $currency);
 }

--- a/test/Twig/Tests/Extension/IntlTest.php
+++ b/test/Twig/Tests/Extension/IntlTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+require_once __DIR__ . '/../../../../lib/Twig/Extensions/Extension/Intl.php';
+
+class Twig_Tests_Extension_IntlTest extends PHPUnit_Framework_TestCase
+{
+
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists('Twig_Extensions_Extension_Intl')) {
+            self::markTestSkipped('Unable to find class Twig_Extensions_Extension_Intl.');
+        }
+        if (!function_exists('twig_localized_currency_filter')) {
+            self::markTestSkipped('Unable to find twig_localized_currency_filter function.');
+        }
+    }
+
+    /**
+     * @dataProvider getCurrencyData
+     */
+    public function testCurrencyFilter($expected, $number, $currency = null, $locale = null, $calculatePrecision=false)
+    {
+        $this->assertEquals(
+            $expected,
+            twig_localized_currency_filter($number, $currency, $locale, $calculatePrecision)
+        );
+    }
+
+    /**
+     * @dataProvider getNumberData
+     */
+    public function testNumberFilter($expected, $number, $style = 'decimal', $type = 'default', $locale = null, $calculatePrecision=false)
+    {
+        $this->assertEquals(
+            $expected,
+            twig_localized_number_filter($number, $style, $type, $locale, $calculatePrecision)
+        );
+    }
+
+    public function getCurrencyData()
+    {
+        return array(
+
+            // Not passing a currency in TEST will result in false
+            array(
+                false,
+                15.00,
+            ),
+            array(
+                "€15.00",
+                15.00,
+                'EUR',
+            ),
+
+            // Test locale
+            array(
+                "15,00 €",
+                15.0023,
+                'EUR',
+                'de_DE',
+            ),
+
+            // Test calculatePrecision
+            array(
+                "€15.00",
+                15.0023,
+                'EUR',
+                null,
+                false,
+            ),
+            array(
+                "€15.0023",
+                15.0023,
+                'EUR',
+                null,
+                true,
+            ),
+            array(
+                "15,0023 €",
+                15.0023,
+                'EUR',
+                'de_DE',
+                true
+            ),
+        );
+    }
+
+    public function getNumberData()
+    {
+        return array(
+            array(
+                15,
+                15.00,
+            ),
+            array(
+                15.00,
+                15.00,
+            ),
+            array(
+                '$15.00',
+                15.00,
+                'currency'
+            ),
+
+            // calculatePrecision
+            array(
+                15.002, // Three decimals by default
+                15.0023,
+                'decimal',
+                'default',
+                null,
+                false,
+            ),
+            array(
+                15.0023, // More decimals when precision is calculated
+                15.0023,
+                'decimal',
+                'default',
+                null,
+                true,
+            ),
+        );
+    }
+}


### PR DESCRIPTION
The Twig Intl Extension `localizednumber` and `localizedcurrency` filters currently do not allow a higher precision than the standard NumberFormatter two digits for currencies and three digits for localizednumbers.

When working with a higher precision it should be possible to calculate the precision. Otherwise the decimals just get lost without a trace. 

* Determine the number of decimals, only modify the formatter attribute if more decimals are needed.
* If the number has no decimal value (eg `15.00` or `15.0000`) the default number of decimals will be used.