### PR TITLE
Right version containing Date Extension

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,7 +23,7 @@ command line:
 
 .. code-block:: bash
 
-    composer require twig/extensions ~1.1.0
+    composer require twig/extensions ~1.2.0
 
 * :doc:`Text <text>`: Provides useful filters for text manipulation;
 


### PR DESCRIPTION
Date extension is available since version 1.2.0 of Twig-extensions

but with the line :
    compose require twig / extensions ~1.1.0  (> = 1.1.0 <1.2.0)

We can't have the Twig-extensions that contains Date
We should be used either  ~1.1  or  ~1.2.0