### PR TITLE
Allow NumberFormatter attributes for localized number/currency filters

### DIFF
--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -59,6 +59,7 @@ representating the number.
 .. code-block:: jinja
 
     {{ product.quantity|localizednumber }}
+    {{ product.height|localizednumber('decimal', 'default', null, {'fraction_digits': 2}) }}
 
 .. note::
 
@@ -89,6 +90,8 @@ Arguments
 * ``locale``: The locale used for the format. If ``NULL`` is given, Twig will
   use ``Locale::getDefault()``
 
+* ``attributes``: Optional array of `NumberFormatter  attributes`_.
+
 ``localizedcurrency``
 ---------------------
 
@@ -111,6 +114,7 @@ Arguments
 * ``locale``: The locale used for the format. If ``NULL`` is given, Twig will
   use ``Locale::getDefault()``
 
+* ``attributes``: Optional array of `NumberFormatter  attributes`_.
 
 .. _`strtotime`:                      http://php.net/strtotime
 .. _`DateTime`:                       http://php.net/DateTime
@@ -135,3 +139,4 @@ Arguments
 .. _`NumberFormatter::TYPE_INT64`:    http://php.net/manual/en/class.numberformatter.php#numberformatter.constants.type-int64
 .. _`NumberFormatter::TYPE_DOUBLE`:   http://php.net/manual/en/class.numberformatter.php#numberformatter.constants.type-double
 .. _`NumberFormatter::TYPE_CURRENCY`: http://php.net/manual/en/class.numberformatter.php#numberformatter.constants.type-currency
+.. _`NumberFormatter attributes`:     http://php.net/manual/en/class.numberformatter.php#intl.numberformatter-constants.unumberformatattribute

--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -67,7 +67,7 @@ function twig_localized_date_filter(Twig_Environment $env, $date, $dateFormat = 
     return $formatter->format($date->getTimestamp());
 }
 
-function twig_localized_number_filter($number, $style = 'decimal', $type = 'default', $locale = null)
+function twig_localized_number_filter($number, $style = 'decimal', $type = 'default', $locale = null, $attributes = array())
 {
     static $typeValues = array(
         'default'   => NumberFormatter::TYPE_DEFAULT,
@@ -77,7 +77,7 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
         'currency'  => NumberFormatter::TYPE_CURRENCY,
     );
 
-    $formatter = twig_get_number_formatter($locale, $style);
+    $formatter = twig_get_number_formatter($locale, $style, $attributes);
 
     if (!isset($typeValues[$type])) {
         throw new Twig_Error_Syntax(sprintf('The type "%s" does not exist. Known types are: "%s"', $type, implode('", "', array_keys($typeValues))));
@@ -86,28 +86,29 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
     return $formatter->format($number, $typeValues[$type]);
 }
 
-function twig_localized_currency_filter($number, $currency = null, $locale = null)
+function twig_localized_currency_filter($number, $currency = null, $locale = null, $attributes = array())
 {
-    $formatter = twig_get_number_formatter($locale, 'currency');
+    $formatter = twig_get_number_formatter($locale, 'currency', $attributes);
 
     return $formatter->formatCurrency($number, $currency);
 }
 
 /**
- * Gets a number formatter instance according to given locale and formatter
+ * Gets a number formatter instance according to given locale and formatter.
  *
- * @param  string $locale Locale in which the number would be formatted
- * @param  int    $style  Style of the formatting
+ * @param  string $locale     Locale in which the number would be formatted
+ * @param  int    $style      Style of the formatting
+ * @param  array  $attributes Number formatter attributes
  *
  * @return NumberFormatter A NumberFormatter instance
  */
-function twig_get_number_formatter($locale, $style)
+function twig_get_number_formatter($locale, $style, $attributes)
 {
-    static $formatter, $currentStyle;
+    static $formatter, $currentStyle, $currentAttributes;
 
     $locale = $locale !== null ? $locale : Locale::getDefault();
 
-    if ($formatter && $formatter->getLocale() === $locale && $currentStyle === $style) {
+    if ($formatter && $formatter->getLocale() === $locale && $currentStyle === $style && $currentAttributes === $attributes) {
         // Return same instance of NumberFormatter if parameters are the same
         // to those in previous call
         return $formatter;
@@ -130,6 +131,16 @@ function twig_get_number_formatter($locale, $style)
     $currentStyle = $style;
 
     $formatter = NumberFormatter::create($locale, $styleValues[$style]);
+
+    foreach ($attributes as $name => $value) {
+        $constantName = strtoupper($name);
+
+        if (!defined('NumberFormatter::'.$constantName)) {
+            throw new Twig_Error_Syntax(sprintf('NumberFormatter has no attribute "%s"', $name));
+        }
+
+        $formatter->setAttribute(constant('NumberFormatter::'.$constantName), $value);
+    }
 
     return $formatter;
 }


### PR DESCRIPTION
This PR makes it possible to pass attributes to the `NumberFormatter` instance when using the  `localizednumber` and `localizedcurrency` filters.
It can be really useful when you need to always display a number with 2 digits for instance, like in the example I added in the documentation:

```
{{ product.height|localizednumber('decimal', 'default', null, {'fraction_digits': 2}) }}
```

I would like to make an other PR to allow the following syntax as well for these filters:

```
{{ product.height|localizednumber({'style': 'percent', 'fraction_digits': 2})
```

Either the available arguments keys for the filters would be `style`, `type`, `locale` and any `NumberFormatter` attribute (lowercased), or `style`, `type`, `locale` and `attributes` (as an other array).
BC-compatibility would be kept.

What do you think of this idea?
