### PR TITLE
Add 'with parameter' to trans token

### DIFF
--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -156,14 +156,16 @@ if ($vars) {
             $msg = $body->getAttribute('data');
         }
 
-        preg_match_all('/(?<!%)%([^%]+)%/', $msg, $matches);
-
-        foreach ($matches[1] as $var) {
-            $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
-            if (!$withVars->hasElement($key)) {
-                $varExpr = new \Twig_Node_Expression_Name($var, $body->getLine());
-                $varExpr->setAttribute('ignore_strict_check', $ignoreStrictCheck);
-                $withVars->addElement($varExpr, $key);
+        if (null !== $withVars) {
+            preg_match_all('/(?<!%)%([^%]+)%/', $msg, $matches);
+    
+            foreach ($matches[1] as $var) {
+                $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
+                if (!$withVars->hasElement($key)) {
+                    $varExpr = new \Twig_Node_Expression_Name($var, $body->getLine());
+                    $varExpr->setAttribute('ignore_strict_check', $ignoreStrictCheck);
+                    $withVars->addElement($varExpr, $key);
+                }
             }
         }
 

--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -78,25 +78,27 @@ class Twig_Extensions_Node_Trans extends Twig_Node
                 ;
             }
             $compiler->raw('array(');
-if ($vars) {
-            foreach ($vars as $var) {
-                if ('count' === $var->getAttribute('name')) {
-                    $compiler
-                        ->string('%count%')
-                        ->raw(' => abs(')
-                        ->subcompile($this->getNode('count'))
-                        ->raw('), ')
-                    ;
-                } else {
-                    $compiler
-                        ->string('%'.$var->getAttribute('name').'%')
-                        ->raw(' => ')
-                        ->subcompile($var)
-                        ->raw(', ')
-                    ;
+            
+            if ($vars) {
+                foreach ($vars as $var) {
+                    if ('count' === $var->getAttribute('name')) {
+                        $compiler
+                            ->string('%count%')
+                            ->raw(' => abs(')
+                            ->subcompile($this->getNode('count'))
+                            ->raw('), ')
+                        ;
+                    } else {
+                        $compiler
+                            ->string('%'.$var->getAttribute('name').'%')
+                            ->raw(' => ')
+                            ->subcompile($var)
+                            ->raw(', ')
+                        ;
+                    }
                 }
             }
-        }
+            
             if (null !== $withVars) {
                 $compiler->raw(') ');
             }

--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -32,6 +32,10 @@ class Twig_Extensions_Node_Trans extends Twig_Node
 
         list($msg, $vars, $withVars) = $this->compileString($this->getNode('body'), $this->getNode('withVars'));
 
+        if (!$withVars->count()) {
+            $withVars = null;
+        }
+
         if (null !== $this->getNode('plural')) {
             list($msg1, $vars1) = $this->compileString($this->getNode('plural'));
 

--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -12,7 +12,6 @@
 /**
  * Represents a trans node.
  *
- * @package    twig
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  */
 class Twig_Extensions_Node_Trans extends Twig_Node
@@ -30,7 +29,7 @@ class Twig_Extensions_Node_Trans extends Twig_Node
     public function compile(Twig_Compiler $compiler)
     {
         $compiler->addDebugInfo($this);
-        
+
         list($msg, $vars, $withVars) = $this->compileString($this->getNode('body'), $this->getNode('withVars'));
 
         if (null !== $this->getNode('plural')) {
@@ -45,7 +44,7 @@ class Twig_Extensions_Node_Trans extends Twig_Node
             $message = trim($notes->getAttribute('data'));
 
             // line breaks are not allowed cause we want a single line comment
-            $message = str_replace(array("\n", "\r"), " ", $message);
+            $message = str_replace(array("\n", "\r"), ' ', $message);
             $compiler->write("// notes: {$message}\n");
         }
 
@@ -78,7 +77,7 @@ class Twig_Extensions_Node_Trans extends Twig_Node
                 ;
             }
             $compiler->raw('array(');
-            
+
             if ($vars) {
                 foreach ($vars as $var) {
                     if ('count' === $var->getAttribute('name')) {
@@ -98,7 +97,7 @@ class Twig_Extensions_Node_Trans extends Twig_Node
                     }
                 }
             }
-            
+
             if (null !== $withVars) {
                 $compiler->raw(') ');
             }
@@ -160,7 +159,7 @@ class Twig_Extensions_Node_Trans extends Twig_Node
 
         if (null !== $withVars) {
             preg_match_all('/(?<!%)%([^%]+)%/', $msg, $matches);
-    
+
             foreach ($matches[1] as $var) {
                 $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
                 if (!$withVars->hasElement($key)) {

--- a/lib/Twig/Extensions/TokenParser/Trans.php
+++ b/lib/Twig/Extensions/TokenParser/Trans.php
@@ -26,7 +26,7 @@ class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
         $notes = null;
 
         $withVars = new \Twig_Node_Expression_Array(array(), $lineno);
-        
+
         if (!$stream->test(Twig_Token::BLOCK_END_TYPE)) {
             if ($stream->test('with')) {
                 $stream->next();
@@ -35,7 +35,7 @@ class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
                 throw new \Twig_Error_Syntax('Unexpected token. Twig was looking for the "with" keyword.', $stream->getCurrent()->getLine(), $stream->getFilename());
             }
         }
-        
+
         $stream->expect(Twig_Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideForFork'));
         $next = $stream->next()->getValue();

--- a/lib/Twig/Extensions/TokenParser/Trans.php
+++ b/lib/Twig/Extensions/TokenParser/Trans.php
@@ -87,7 +87,7 @@ class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
         return 'trans';
     }
 
-    protected function checkTransString(Twig_NodeInterface $body, $lineno)
+    private function checkTransString(Twig_NodeInterface $body, $lineno)
     {
         foreach ($body as $i => $node) {
             if (
@@ -102,7 +102,7 @@ class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
         }
     }
 
-    protected function checkWithNode($with, $plural, $lineno)
+    private function checkWithNode($with, $plural, $lineno)
     {
         if (null !== $with && null !== $plural) {
             $key = new Twig_Node_Expression_Constant('%count%', $lineno);

--- a/test/Twig/Tests/Node/TransTest.php
+++ b/test/Twig/Tests/Node/TransTest.php
@@ -102,11 +102,11 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         $plural = new Twig_Node(array(
             new Twig_Node_Text('There are ', 0),
             new Twig_Node_Print(new Twig_Node_Expression_Name('count', 0), 0),
-            new Twig_Node_Text(' pending tasks', 0)
+            new Twig_Node_Text(' pending tasks', 0),
         ), array(), 0);
-        $notes = new Twig_Node_Text("Notes for translators", 0);
+        $notes = new Twig_Node_Text('Notes for translators', 0);
         $node = new Twig_Extensions_Node_Trans($body, null, $plural, $count, $notes, 0);
-        $tests[] = array($node, "// notes: Notes for translators\n" . 'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));');
+        $tests[] = array($node, "// notes: Notes for translators\n".'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));');
 
         return $tests;
     }

--- a/test/Twig/Tests/Node/TransTest.php
+++ b/test/Twig/Tests/Node/TransTest.php
@@ -27,7 +27,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
             new Twig_Node_Print(new Twig_Node_Expression_Name('count', 0), 0),
             new Twig_Node_Text(' apples', 0),
         ), array(), 0);
-        $node = new Twig_Extensions_Node_Trans($body, $plural, $count, null, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, $plural, $count, null, 0);
 
         $this->assertEquals($body, $node->getNode('body'));
         $this->assertEquals($count, $node->getNode('count'));
@@ -39,17 +39,17 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         $tests = array();
 
         $body = new Twig_Node_Expression_Name('foo', 0);
-        $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, null, 0);
         $tests[] = array($node, sprintf('echo gettext(%s);', $this->getVariableGetter('foo')));
 
         $body = new Twig_Node_Expression_Constant('Hello', 0);
-        $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, null, 0);
         $tests[] = array($node, 'echo gettext("Hello");');
 
         $body = new Twig_Node(array(
             new Twig_Node_Text('Hello', 0),
         ), array(), 0);
-        $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, null, 0);
         $tests[] = array($node, 'echo gettext("Hello");');
 
         $body = new Twig_Node(array(
@@ -57,7 +57,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
             new Twig_Node_Print(new Twig_Node_Expression_Name('foo', 0), 0),
             new Twig_Node_Text(' pommes', 0),
         ), array(), 0);
-        $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, null, 0);
         $tests[] = array($node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s, ));', $this->getVariableGetter('foo')));
 
         $count = new Twig_Node_Expression_Constant(12, 0);
@@ -73,7 +73,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
             new Twig_Node_Print(new Twig_Node_Expression_Name('count', 0), 0),
             new Twig_Node_Text(' apples', 0),
         ), array(), 0);
-        $node = new Twig_Extensions_Node_Trans($body, $plural, $count, null, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, $plural, $count, null, 0);
         $tests[] = array($node, sprintf('echo strtr(ngettext("Hey %%name%%, I have one apple", "Hey %%name%%, I have %%count%% apples", abs(12)), array("%%name%%" => %s, "%%name%%" => %s, "%%count%%" => abs(12), ));', $this->getVariableGetter('name'), $this->getVariableGetter('name')));
 
         // with escaper extension set to on
@@ -83,18 +83,18 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
             new Twig_Node_Text(' pommes', 0),
         ), array(), 0);
 
-        $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, null, 0);
         $tests[] = array($node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s, ));', $this->getVariableGetter('foo')));
 
         // with notes
         $body = new Twig_Node_Expression_Constant('Hello', 0);
         $notes = new Twig_Node_Text('Notes for translators', 0);
-        $node = new Twig_Extensions_Node_Trans($body, null, null, $notes, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, $notes, 0);
         $tests[] = array($node, "// notes: Notes for translators\necho gettext(\"Hello\");");
 
         $body = new Twig_Node_Expression_Constant('Hello', 0);
         $notes = new Twig_Node_Text("Notes for translators\nand line breaks", 0);
-        $node = new Twig_Extensions_Node_Trans($body, null, null, $notes, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, $notes, 0);
         $tests[] = array($node, "// notes: Notes for translators and line breaks\necho gettext(\"Hello\");");
 
         $count = new Twig_Node_Expression_Constant(5, 0);
@@ -105,7 +105,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
             new Twig_Node_Text(' pending tasks', 0)
         ), array(), 0);
         $notes = new Twig_Node_Text("Notes for translators", 0);
-        $node = new Twig_Extensions_Node_Trans($body, $plural, $count, $notes, 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, $plural, $count, $notes, 0);
         $tests[] = array($node, "// notes: Notes for translators\n" . 'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));');
 
         return $tests;

--- a/test/Twig/Tests/Node/TransTest.php
+++ b/test/Twig/Tests/Node/TransTest.php
@@ -74,7 +74,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
             new Twig_Node_Text(' apples', 0),
         ), array(), 0);
         $node = new Twig_Extensions_Node_Trans($body, null, $plural, $count, null, 0);
-        $tests[] = array($node, sprintf('echo strtr(ngettext("Hey %%name%%, I have one apple", "Hey %%name%%, I have %%count%% apples", 12), array("%%name%%" => %s, "%%name%%" => %s, "%%count%%" => 12));', $this->getVariableGetter('name'), $this->getVariableGetter('name')));
+        $tests[] = array($node, sprintf('echo strtr(ngettext("Hey %%name%%, I have one apple", "Hey %%name%%, I have %%count%% apples", 12), array("%%name%%" => %s, "%%count%%" => 12));', $this->getVariableGetter('name')));
 
         // with escaper extension set to on
         $body = new Twig_Node(array(

--- a/test/Twig/Tests/Node/TransTest.php
+++ b/test/Twig/Tests/Node/TransTest.php
@@ -58,7 +58,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
             new Twig_Node_Text(' pommes', 0),
         ), array(), 0);
         $node = new Twig_Extensions_Node_Trans($body, null, null, null, null, 0);
-        $tests[] = array($node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s, ));', $this->getVariableGetter('foo')));
+        $tests[] = array($node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s));', $this->getVariableGetter('foo')));
 
         $count = new Twig_Node_Expression_Constant(12, 0);
         $body = new Twig_Node(array(
@@ -74,7 +74,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
             new Twig_Node_Text(' apples', 0),
         ), array(), 0);
         $node = new Twig_Extensions_Node_Trans($body, null, $plural, $count, null, 0);
-        $tests[] = array($node, sprintf('echo strtr(ngettext("Hey %%name%%, I have one apple", "Hey %%name%%, I have %%count%% apples", abs(12)), array("%%name%%" => %s, "%%name%%" => %s, "%%count%%" => abs(12), ));', $this->getVariableGetter('name'), $this->getVariableGetter('name')));
+        $tests[] = array($node, sprintf('echo strtr(ngettext("Hey %%name%%, I have one apple", "Hey %%name%%, I have %%count%% apples", 12), array("%%name%%" => %s, "%%name%%" => %s, "%%count%%" => 12));', $this->getVariableGetter('name'), $this->getVariableGetter('name')));
 
         // with escaper extension set to on
         $body = new Twig_Node(array(
@@ -84,7 +84,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         ), array(), 0);
 
         $node = new Twig_Extensions_Node_Trans($body, null, null, null, null, 0);
-        $tests[] = array($node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s, ));', $this->getVariableGetter('foo')));
+        $tests[] = array($node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s));', $this->getVariableGetter('foo')));
 
         // with notes
         $body = new Twig_Node_Expression_Constant('Hello', 0);
@@ -106,7 +106,7 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         ), array(), 0);
         $notes = new Twig_Node_Text('Notes for translators', 0);
         $node = new Twig_Extensions_Node_Trans($body, null, $plural, $count, $notes, 0);
-        $tests[] = array($node, "// notes: Notes for translators\n".'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));');
+        $tests[] = array($node, "// notes: Notes for translators\n".'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", 5), array("%count%" => 5));');
 
         return $tests;
     }


### PR DESCRIPTION
Add a "with" syntax to trans token similar to "include" tag.
Usage:

```
{% trans with {'%name%': name|capitalize, '%site_url%':'<a href="http://www.mysite.com" alt="mysite">my website</a>'} %}
    Hello %name%! Welcome to %site_url%
{% endtrans %}
```
