### PR TITLE
Add ability to set locale domain when using i18n

### DIFF
--- a/doc/i18n.rst
+++ b/doc/i18n.rst
@@ -48,6 +48,19 @@ Use the ``trans`` block to mark parts in the template as translatable:
         Hello World!
     {% endtrans %}
 
+An optional translation domain can be provided as second parameter:
+
+.. code-block:: jinja
+
+    {% trans "Hello World!" "mydomain" %}
+
+    {% trans "Hello World!" string_var %}
+
+    {% trans %}
+    {% domain "mydomain" %}
+        Hello World!
+    {% endtrans %}
+
 In a translatable string, you can embed variables:
 
 .. code-block:: jinja
@@ -101,6 +114,19 @@ To add notes for translators, use the ``notes`` block:
 
 You can use ``notes`` with or without ``plural``. Once you get your templates compiled you should
 configure the ``gettext`` parser to get something like this: ``xgettext --add-comments=notes``
+
+To add a translation domain, use the ``domain`` block:
+
+.. code-block:: jinja
+
+    {% trans %}
+    {% domain gettext_domain %}
+        Hey {{ name }}, I have one apple.
+    {% plural apple_count %}
+        Hey {{ name }}, I have {{ count }} apples.
+    {% notes %}
+        This is shown in the user menu. This string should be shorter than 30 chars
+    {% endtrans %}
 
 Within an expression or in a tag, you can use the ``trans`` filter to translate
 simple strings or variables:

--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -17,9 +17,9 @@
  */
 class Twig_Extensions_Node_Trans extends Twig_Node
 {
-    public function __construct(Twig_NodeInterface $body, Twig_NodeInterface $plural = null, Twig_Node_Expression $count = null, Twig_NodeInterface $notes = null, $lineno, $tag = null)
+    public function __construct(Twig_NodeInterface $body, Twig_NodeInterface $plural = null, Twig_Node_Expression $count = null, Twig_NodeInterface $notes = null, $lineno, $tag = null, Twig_Node_Expression $domain = null)
     {
-        parent::__construct(array('count' => $count, 'body' => $body, 'plural' => $plural, 'notes' => $notes), array(), $lineno, $tag);
+        parent::__construct(array('count' => $count, 'body' => $body, 'plural' => $plural, 'notes' => $notes, 'domain' => $domain), array(), $lineno, $tag);
     }
 
     /**
@@ -39,7 +39,11 @@ class Twig_Extensions_Node_Trans extends Twig_Node
             $vars = array_merge($vars, $vars1);
         }
 
-        $function = null === $this->getNode('plural') ? 'gettext' : 'ngettext';
+        if (null === $domain = $this->getNode('domain')) {
+            $function = null === $this->getNode('plural') ? 'gettext' : 'ngettext';
+        } else {
+            $function = null === $this->getNode('plural') ? 'dgettext' : 'dngettext';
+        }
 
         if (null !== $notes = $this->getNode('notes')) {
             $message = trim($notes->getAttribute('data'));
@@ -52,6 +56,14 @@ class Twig_Extensions_Node_Trans extends Twig_Node
         if ($vars) {
             $compiler
                 ->write('echo strtr('.$function.'(')
+            ;
+            if ($domain) {
+                $compiler
+                    ->subcompile($domain)
+                    ->raw(', ')
+                ;
+            }
+            $compiler
                 ->subcompile($msg)
             ;
 
@@ -89,6 +101,14 @@ class Twig_Extensions_Node_Trans extends Twig_Node
         } else {
             $compiler
                 ->write('echo '.$function.'(')
+            ;
+            if ($domain) {
+                $compiler
+                    ->subcompile($domain)
+                    ->raw(', ')
+                ;
+            }
+            $compiler
                 ->subcompile($msg)
             ;
 

--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -12,7 +12,6 @@
 /**
  * Represents a trans node.
  *
- * @package    twig
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  */
 class Twig_Extensions_Node_Trans extends Twig_Node
@@ -49,7 +48,7 @@ class Twig_Extensions_Node_Trans extends Twig_Node
             $message = trim($notes->getAttribute('data'));
 
             // line breaks are not allowed cause we want a single line comment
-            $message = str_replace(array("\n", "\r"), " ", $message);
+            $message = str_replace(array("\n", "\r"), ' ', $message);
             $compiler->write("// notes: {$message}\n");
         }
 

--- a/test/Twig/Tests/Node/TransTest.php
+++ b/test/Twig/Tests/Node/TransTest.php
@@ -153,11 +153,11 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         $plural = new Twig_Node(array(
             new Twig_Node_Text('There are ', 0),
             new Twig_Node_Print(new Twig_Node_Expression_Name('count', 0), 0),
-            new Twig_Node_Text(' pending tasks', 0)
+            new Twig_Node_Text(' pending tasks', 0),
         ), array(), 0);
-        $notes = new Twig_Node_Text("Notes for translators", 0);
+        $notes = new Twig_Node_Text('Notes for translators', 0);
         $node = new Twig_Extensions_Node_Trans($body, $plural, $count, $notes, 0);
-        $tests[] = array($node, "// notes: Notes for translators\n" . 'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));');
+        $tests[] = array($node, "// notes: Notes for translators\n".'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));');
 
         return $tests;
     }

--- a/test/Twig/Tests/Node/TransTest.php
+++ b/test/Twig/Tests/Node/TransTest.php
@@ -12,7 +12,7 @@
 class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
 {
     /**
-     * @covers Twig_Node_Trans::__construct
+     * @covers Twig_Extensions_Node_Trans::__construct
      */
     public function testConstructor()
     {
@@ -34,6 +34,26 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         $this->assertEquals($plural, $node->getNode('plural'));
     }
 
+    public function testContructorWithDomain()
+    {
+        $count = new Twig_Node_Expression_Constant(12, 0);
+        $body = new Twig_Node(array(
+            new Twig_Node_Text('Hello', 0),
+        ), array(), 0);
+        $plural = new Twig_Node(array(
+            new Twig_Node_Text('Hey ', 0),
+            new Twig_Node_Print(new Twig_Node_Expression_Name('name', 0), 0),
+            new Twig_Node_Text(', I have ', 0),
+            new Twig_Node_Print(new Twig_Node_Expression_Name('count', 0), 0),
+            new Twig_Node_Text(' apples', 0),
+        ), array(), 0);
+        $domain = new Twig_Node_Expression_Constant('foo', 0);
+
+        $node = new Twig_Extensions_Node_Trans($body, $plural, $count, null, 0, null, $domain);
+
+        $this->assertEquals($domain, $node->getNode('domain'));
+    }
+
     public function getTests()
     {
         $tests = array();
@@ -41,6 +61,11 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         $body = new Twig_Node_Expression_Name('foo', 0);
         $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
         $tests[] = array($node, sprintf('echo gettext(%s);', $this->getVariableGetter('foo')));
+
+        $body = new Twig_Node_Expression_Name('foo', 0);
+        $domain = new Twig_Node_Expression_Constant('foo_domain', 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0, null, $domain);
+        $tests[] = array($node, sprintf('echo dgettext("foo_domain", %s);', $this->getVariableGetter('foo')));
 
         $body = new Twig_Node_Expression_Constant('Hello', 0);
         $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
@@ -60,6 +85,15 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
         $tests[] = array($node, sprintf('echo strtr(gettext("J\'ai %%foo%% pommes"), array("%%foo%%" => %s, ));', $this->getVariableGetter('foo')));
 
+        $body = new Twig_Node(array(
+            new Twig_Node_Text('J\'ai ', 0),
+            new Twig_Node_Print(new Twig_Node_Expression_Name('foo', 0), 0),
+            new Twig_Node_Text(' pommes', 0),
+        ), array(), 0);
+        $domain = new Twig_Node_Expression_Constant('foo_domain', 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0, null, $domain);
+        $tests[] = array($node, sprintf('echo strtr(dgettext("foo_domain", "J\'ai %%foo%% pommes"), array("%%foo%%" => %s, ));', $this->getVariableGetter('foo')));
+
         $count = new Twig_Node_Expression_Constant(12, 0);
         $body = new Twig_Node(array(
             new Twig_Node_Text('Hey ', 0),
@@ -75,6 +109,23 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         ), array(), 0);
         $node = new Twig_Extensions_Node_Trans($body, $plural, $count, null, 0);
         $tests[] = array($node, sprintf('echo strtr(ngettext("Hey %%name%%, I have one apple", "Hey %%name%%, I have %%count%% apples", abs(12)), array("%%name%%" => %s, "%%name%%" => %s, "%%count%%" => abs(12), ));', $this->getVariableGetter('name'), $this->getVariableGetter('name')));
+
+        $count = new Twig_Node_Expression_Constant(12, 0);
+        $body = new Twig_Node(array(
+            new Twig_Node_Text('Hey ', 0),
+            new Twig_Node_Print(new Twig_Node_Expression_Name('name', 0), 0),
+            new Twig_Node_Text(', I have one apple', 0),
+        ), array(), 0);
+        $plural = new Twig_Node(array(
+            new Twig_Node_Text('Hey ', 0),
+            new Twig_Node_Print(new Twig_Node_Expression_Name('name', 0), 0),
+            new Twig_Node_Text(', I have ', 0),
+            new Twig_Node_Print(new Twig_Node_Expression_Name('count', 0), 0),
+            new Twig_Node_Text(' apples', 0),
+        ), array(), 0);
+        $domain = new Twig_Node_Expression_Constant('foo_domain', 0);
+        $node = new Twig_Extensions_Node_Trans($body, $plural, $count, null, 0, null, $domain);
+        $tests[] = array($node, sprintf('echo strtr(dngettext("foo_domain", "Hey %%name%%, I have one apple", "Hey %%name%%, I have %%count%% apples", abs(12)), array("%%name%%" => %s, "%%name%%" => %s, "%%count%%" => abs(12), ));', $this->getVariableGetter('name'), $this->getVariableGetter('name')));
 
         // with escaper extension set to on
         $body = new Twig_Node(array(


### PR DESCRIPTION
When using i18n extension, there currently are no ways to provide a locale domain.

This PR enables use of `dgettext`, `dngettext` when an optional domain is provided.

``` twig
{% trans 'key' 'domain' %}
{% trans %}
{% domain 'messages' %}
  To translate
{% endtrans %}
```
