### PR TITLE
Use DateTimeZone object instead of the name in localizeddate()

### DIFF
--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -48,18 +48,18 @@ function twig_localized_date_filter(Twig_Environment $env, $date, $dateFormat = 
     $date = twig_date_converter($env, $date, $timezone);
 
     $formatValues = array(
-        'none'   => IntlDateFormatter::NONE,
-        'short'  => IntlDateFormatter::SHORT,
+        'none' => IntlDateFormatter::NONE,
+        'short' => IntlDateFormatter::SHORT,
         'medium' => IntlDateFormatter::MEDIUM,
-        'long'   => IntlDateFormatter::LONG,
-        'full'   => IntlDateFormatter::FULL,
+        'long' => IntlDateFormatter::LONG,
+        'full' => IntlDateFormatter::FULL,
     );
 
     $formatter = IntlDateFormatter::create(
         $locale,
         $formatValues[$dateFormat],
         $formatValues[$timeFormat],
-        $date->getTimezone()->getName(),
+        PHP_VERSION_ID >= 50500 ? $date->getTimezone() : $date->getTimezone()->getName(),
         IntlDateFormatter::GREGORIAN,
         $format
     );
@@ -70,11 +70,11 @@ function twig_localized_date_filter(Twig_Environment $env, $date, $dateFormat = 
 function twig_localized_number_filter($number, $style = 'decimal', $type = 'default', $locale = null)
 {
     static $typeValues = array(
-        'default'   => NumberFormatter::TYPE_DEFAULT,
-        'int32'     => NumberFormatter::TYPE_INT32,
-        'int64'     => NumberFormatter::TYPE_INT64,
-        'double'    => NumberFormatter::TYPE_DOUBLE,
-        'currency'  => NumberFormatter::TYPE_CURRENCY,
+        'default' => NumberFormatter::TYPE_DEFAULT,
+        'int32' => NumberFormatter::TYPE_INT32,
+        'int64' => NumberFormatter::TYPE_INT64,
+        'double' => NumberFormatter::TYPE_DOUBLE,
+        'currency' => NumberFormatter::TYPE_CURRENCY,
     );
 
     $formatter = twig_get_number_formatter($locale, $style);
@@ -94,10 +94,10 @@ function twig_localized_currency_filter($number, $currency = null, $locale = nul
 }
 
 /**
- * Gets a number formatter instance according to given locale and formatter
+ * Gets a number formatter instance according to given locale and formatter.
  *
- * @param  string $locale Locale in which the number would be formatted
- * @param  int    $style  Style of the formatting
+ * @param string $locale Locale in which the number would be formatted
+ * @param int    $style  Style of the formatting
  *
  * @return NumberFormatter A NumberFormatter instance
  */
@@ -114,13 +114,13 @@ function twig_get_number_formatter($locale, $style)
     }
 
     static $styleValues = array(
-        'decimal'       => NumberFormatter::DECIMAL,
-        'currency'      => NumberFormatter::CURRENCY,
-        'percent'       => NumberFormatter::PERCENT,
-        'scientific'    => NumberFormatter::SCIENTIFIC,
-        'spellout'      => NumberFormatter::SPELLOUT,
-        'ordinal'       => NumberFormatter::ORDINAL,
-        'duration'      => NumberFormatter::DURATION,
+        'decimal' => NumberFormatter::DECIMAL,
+        'currency' => NumberFormatter::CURRENCY,
+        'percent' => NumberFormatter::PERCENT,
+        'scientific' => NumberFormatter::SCIENTIFIC,
+        'spellout' => NumberFormatter::SPELLOUT,
+        'ordinal' => NumberFormatter::ORDINAL,
+        'duration' => NumberFormatter::DURATION,
     );
 
     if (!isset($styleValues[$style])) {

--- a/test/Twig/Tests/Extension/IntlTest.php
+++ b/test/Twig/Tests/Extension/IntlTest.php
@@ -15,6 +15,13 @@ require_once __DIR__.'/../../../../lib/Twig/Extensions/Extension/Intl.php';
  */
 class Twig_Tests_Extension_IntlTest extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        if (!class_exists('IntlDateFormatter')) {
+            $this->markTestSkipped('The intl extension is needed to use intl-based filters.');
+        }
+    }
+
     public function testLocalizedDateFilterWithDateTimeZone()
     {
         if (PHP_VERSION_ID < 50500) {

--- a/test/Twig/Tests/Extension/IntlTest.php
+++ b/test/Twig/Tests/Extension/IntlTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+require_once __DIR__.'/../../../../lib/Twig/Extensions/Extension/Intl.php';
+
+/**
+ * @author Remy Gazelot <r.gazelot@gmail.com>
+ */
+class Twig_Tests_Extension_IntlTest extends PHPUnit_Framework_TestCase
+{
+    public function testLocalizedDateFilterWithDateTimeZone()
+    {
+        if (PHP_VERSION_ID < 50500) {
+            $this->markTestSkipped('Only in PHP 5.5+ IntlDateFormatter allows to use DateTimeZone objects.');
+        }
+
+        if (defined('HHVM_VERSION_ID')) {
+            $this->markTestSkipped('This test cannot work on HHVM. See https://github.com/facebook/hhvm/issues/5875 for the issue.');
+        }
+
+        $date = twig_localized_date_filter(
+            $this->env = $this->getMock('Twig_Environment'),
+            new DateTime('2015-01-01T00:00:00', new DateTimeZone('UTC')),
+            'short',
+            'long',
+            'en',
+            '+02:00'
+        );
+
+        $this->assertEquals('1/1/15 2:00:00 AM GMT+02:00', $date);
+    }
+}

--- a/test/Twig/Tests/Extension/IntlTest.php
+++ b/test/Twig/Tests/Extension/IntlTest.php
@@ -43,4 +43,26 @@ class Twig_Tests_Extension_IntlTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('1/1/15 2:00:00 AM GMT+02:00', $date);
     }
+
+    public function testLocalizedDateFilterWithDateTimeZoneOnHHVM()
+    {
+        if (PHP_VERSION_ID < 50500) {
+            $this->markTestSkipped('Only in PHP 5.5+ IntlDateFormatter allows to use DateTimeZone objects.');
+        }
+
+        if (!defined('HHVM_VERSION_ID')) {
+            $this->markTestSkipped('This test is specific for HHVM.');
+        }
+
+        $date = twig_localized_date_filter(
+            $this->env = $this->getMock('Twig_Environment'),
+            new DateTime('2015-01-01T00:00:00', new DateTimeZone('UTC')),
+            'short',
+            'long',
+            'en',
+            'Europe/Paris'
+        );
+
+        $this->assertEquals('1/1/15 1:00:00 AM GMT+01:00', $date);
+    }
 }


### PR DESCRIPTION
In my case, my timezone's name returned by ``DateTime`` object is "+02:00". When I use this name with the ``localizedate()`` function, it correctly convert the date with the ``twig_date_converter()`` but the ``IntlDateFormater::create()`` returns ``null``.

When I read the doc and this issue : https://bugs.php.net/bug.php?id=66323, I have concluded that my name doesn't match with the ICU database as needed.

As to give a ``DateTimeZone`` object is possible, I think it could be more interesting to give the date's timezone object instead of it's name to avoid this kind of errors.