### PR TITLE
Add a filesize extension for human readable filesizes

### DIFF
--- a/doc/filesize.rst
+++ b/doc/filesize.rst
@@ -1,0 +1,72 @@
+The Filesize Extension
+======================
+
+The *Filesize* extension provides the ``filesize`` filter.
+
+You need to register this extension before using the ``filesize`` filter::
+
+    $twig->addExtension(new Twig_Extensions_Extension_Filesize());
+
+``filesize``
+------------
+
+Use the ``filesize`` filter to render a human readable filesize
+
+.. code-block:: jinja
+
+    {{ download.size|filesize }}
+
+The example above will output a filesize in byte like ``4 MiB``  or ``24 KiB``,
+depending on the filtered filesize.
+
+Arguments
+~~~~~~~~~
+
+* ``size``: A float/int/string of the size to format
+
+* ``fixed_suffix``: Optionally use this fixed suffix to calculate. Must be a
+    correct filesize suffix and corresponding to ``power_of_two``.
+
+* ``power_of_two``: True or false, whether to use powers of 2 or 10.
+
+* ``decimal``: The number of decimal points to display
+
+* ``decimal_point``: The character(s) to use for the decimal point
+
+* ``thousand_sep``: The character(s) to use for the thousands separator
+
+Defaults
+~~~~~~~~
+
+If no formatting options are provided then Twig will use the default formatting
+options of:
+
+* Suffix is calculated automatically.
+* Power of 2 for the calculation base.
+* 0 decimal places.
+* ``.`` as the decimal point.
+* ``,`` as the thousands separator.
+
+The filesize defaults (suffix and power of 2) can either be set in the
+constructor of the extension:
+
+.. code-block:: php
+
+    $twig->addExtension(new Twig_Extensions_Extension_Filesize('MB', false));
+
+Or through retrieving the filesize extension and a setter:
+
+.. code-block:: php
+
+    $twig->getExtension('filesize')->setDefaults('MB', false);
+
+The number formatting defaults are retrieved through the defaults of the core
+extension and can be easily changed through the core extension:
+
+.. code-block:: php
+
+    $twig->getExtension('core')->setNumberFormat(3, '.', ',');
+
+The defaults set for ``filesize`` can be over-ridden upon each call using the
+additional parameters.
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,7 @@ Twig Extensions
     intl
     array
     date
+    filesize
 
 The Twig Extensions is a library that provides several useful extensions
 for Twig. You can find it's code at `GitHub.com/twigphp/Twig-extensions`_.
@@ -35,5 +36,7 @@ command line:
 * :doc:`Array <array>`: Provides useful filters for array manipulation;
 
 * :doc:`Date <date>`: Adds a filter for rendering the difference between dates.
+
+* :doc:`Filesize <filesize>`: Adds a filter for rendering human readable filesizes.
 
 .. _`GitHub.com/twigphp/Twig-extensions`: https://github.com/twigphp/Twig-extensions

--- a/lib/Twig/Extensions/Extension/Filesize.php
+++ b/lib/Twig/Extensions/Extension/Filesize.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2015 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Filesize extension for human readable filesizes.
+ *
+ * @author Patrik Karisch <p.karisch@pixelart.at>
+ */
+class Twig_Extensions_Extension_Filesize extends \Twig_Extension
+{
+    private static $two = array('Byte', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB');
+    private static $ten = array('Byte', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB');
+
+    /**
+     * The default suffix.
+     *
+     * @var string|null
+     */
+    private $fixedSuffix;
+
+    /**
+     * Use power of 2 or 10 if not given in the filter.
+     *
+     * @var bool
+     */
+    private $powerOfTwo;
+
+    /**
+     * @param string $fixedSuffix Use this fixed suffix to calculate. Must be a correct
+     *                            filesize suffix and corresponding to $powerOfTwo.
+     * @param bool   $powerOfTwo  Whether to use powers of 2 or 10.
+     */
+    public function __construct($fixedSuffix = null, $powerOfTwo = true)
+    {
+        $this->fixedSuffix = $fixedSuffix;
+        $this->powerOfTwo = $powerOfTwo;
+    }
+
+    /**
+     * @return string|null The default suffix to use when calculating or none.
+     */
+    public function getFixedSuffix()
+    {
+        return $this->fixedSuffix;
+    }
+
+    /**
+     * @param string|null $fixedSuffix Use this fixed suffix to calculate. Must be a correct
+     *                                 filesize suffix and corresponding to $powerOfTwo or null.
+     */
+    public function setFixedSuffix($fixedSuffix)
+    {
+        $this->fixedSuffix = $fixedSuffix;
+    }
+
+    /**
+     * @return bool Use power of 2 or 10 if not given in the filter.
+     */
+    public function isPowerOfTwo()
+    {
+        return $this->powerOfTwo;
+    }
+
+    /**
+     * @param bool $powerOfTwo Whether to use powers of 2 or 10.
+     */
+    public function setPowerOfTwo($powerOfTwo)
+    {
+        $this->powerOfTwo = $powerOfTwo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('filesize', array($this, 'filesize'), array(
+                'needs_environment' => true,
+            )),
+        );
+    }
+
+    /**
+     * Calculates a human readable file size from a file size in bytes.
+     *
+     * @param Twig_Environment $env          A Twig_Environment instance.
+     * @param mixed            $size         A float/int/string of the size to format.
+     * @param string           $fixedSuffix  Use this fixed suffix to calculate. Must be a correct
+     *                                       filesize suffix and corresponding to $powerOfTwo.
+     * @param bool             $powerOfTwo   Whether to use powers of 2 or 10.
+     * @param int              $decimal      The number of decimal points to display.
+     * @param string           $decimalPoint The character(s) to use for the decimal point.
+     * @param string           $thousandSep  The character(s) to use for the thousands separator.
+     *
+     * @return string The file size with prefix.
+     */
+    public function filesize(Twig_Environment $env, $size, $fixedSuffix = null, $powerOfTwo = null, $decimal = null, $decimalPoint = null, $thousandSep = null) {
+        if (null === $fixedSuffix) {
+            $fixedSuffix = $this->fixedSuffix;
+        }
+        if (null === $powerOfTwo) {
+            $powerOfTwo = $this->powerOfTwo;
+        }
+        $numberDefaults = $env->getExtension('core')->getNumberFormat();
+        if (null === $decimal) {
+            $decimal = $numberDefaults[0];
+        }
+        if (null === $decimalPoint) {
+            $decimalPoint = $numberDefaults[1];
+        }
+        if (null === $thousandSep) {
+            $thousandSep = $numberDefaults[2];
+        }
+
+        $divide = $powerOfTwo ? 1024 : 1000;
+        $suffix = $powerOfTwo ? self::$two : self::$ten;
+
+        $cycles = count($suffix);
+        if ($fixedSuffix !== null && false !== $suffixKey = array_search(
+                $fixedSuffix,
+                $suffix,
+                true
+            )
+        ) {
+            $size /= pow($divide, $suffixKey);
+        } else {
+            for ($suffixKey = 0; $size > $divide && $suffixKey < $cycles; ++$suffixKey) {
+                $size /= $divide;
+            }
+
+            if ($suffixKey >= $cycles) {
+                --$suffixKey;
+            }
+        }
+
+        $size = round($size, $decimal);
+        $size = number_format($size, $decimal, $decimalPoint, $thousandSep);
+
+        return $size.' '.$suffix[$suffixKey];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'filesize';
+    }
+}

--- a/test/Twig/Tests/Extension/FilesizeTest.php
+++ b/test/Twig/Tests/Extension/FilesizeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2015 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @author Patrik Karisch <p.karisch@pixelart.at>
+ */
+class Twig_Tests_Extension_FilesizeTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Twig_Environment
+     */
+    private $env;
+
+    protected function setUp()
+    {
+        $coreExtension = $this->getMock('Twig_Extension_Core');
+        $coreExtension
+            ->expects($this->any())
+            ->method('getNumberFormat')
+            ->will($this->returnValue(array(0, '.', ',')));
+
+        $this->env = $this->getMockBuilder('Twig_Environment')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->env
+            ->expects($this->any())
+            ->method('getExtension')
+            ->with('core')
+            ->will($this->returnValue($coreExtension))
+        ;
+    }
+
+    /**
+     * @dataProvider getFilesizeDefaultTestData()
+     */
+    public function testFilesizeWithDefaults($expected, $size, $powerOfTwo)
+    {
+        $extension = new Twig_Extensions_Extension_Filesize();
+        $this->assertEquals($expected, $extension->filesize($this->env, $size, null, $powerOfTwo));
+    }
+
+    /**
+     * @dataProvider getFilesizeVariableDecimalTestData()
+     */
+    public function testFilesizeWithVariableDecimal($expected, $decimal, $powerOfTwo)
+    {
+        $extension = new Twig_Extensions_Extension_Filesize();
+        $this->assertEquals($expected, $extension->filesize($this->env, 752378952, null, $powerOfTwo, $decimal));
+    }
+
+    /**
+     * @dataProvider getFilesizeFixedSuffixTestData()
+     */
+    public function testFilesizeWithFixedSuffix($expected, $size, $suffix, $powerOfTwo)
+    {
+        $extension = new Twig_Extensions_Extension_Filesize();
+        $this->assertEquals($expected, $extension->filesize($this->env, $size, $suffix, $powerOfTwo, 2));
+    }
+
+    public function getFilesizeDefaultTestData()
+    {
+        return array(
+            array('10 Byte', '10', true),
+            array('10 KiB', '10240', true),
+            array('10 MiB', '10485760', true),
+            array('10 GiB', '10737418240', true),
+            array('10 TiB', '10995116277760', true),
+            array('10 PiB', '11258999068426240', true),
+            array('5 EiB', '5764607523034234880', true),
+            array('10 Byte', '10', false),
+            array('10 kB', '10000', false),
+            array('10 MB', '10000000', false),
+            array('10 GB', '10000000000', false),
+            array('10 TB', '10000000000000', false),
+            array('10 PB', '10000000000000000', false),
+            array('5 EB', '5000000000000000000', false),
+        );
+    }
+
+    public function getFilesizeVariableDecimalTestData()
+    {
+        return array(
+            array('718 MiB', 0, true),
+            array('717.5 MiB', 1, true),
+            array('717.52 MiB', 2, true),
+            array('717.524 MiB', 3, true),
+            array('717.5245 MiB', 4, true),
+            array('717.52448 MiB', 5, true),
+            array('752 MB', 0, false),
+            array('752.4 MB', 1, false),
+            array('752.38 MB', 2, false),
+            array('752.379 MB', 3, false),
+            array('752.3790 MB', 4, false),
+            array('752.37895 MB', 5, false),
+        );
+    }
+
+    public function getFilesizeFixedSuffixTestData()
+    {
+        return array(
+            array('471,859.00 Byte', '471859', 'Byte', true),
+            array('0.45 MiB', '471859', 'MiB', true),
+            array('1,545.36 MiB', '1620427407', 'MiB', true),
+            array('750,000.00 Byte', '750000', 'Byte', false),
+            array('0.75 MB', '750000', 'MB', false),
+            array('4,543.78 MB', '4543780000', 'MB', false),
+        );
+    }
+}


### PR DESCRIPTION
Add a filesize extension for human readable filesizes with some mutations.

Without extra parameters the filter calculates with powers of 2 (1024) and automatically calculates a suffix to use. The user can define a fixed suffix, for example all downloads should be in MiB, or can change to calculate with powers of 10 (1000). And the same settings which are applicable to number format.

All this options are done trough arguments in the filter directly or through setting the defaults on constructing the extension or later via setter. The defaults for the final number format are retrieved from the core extension.
