### PR TITLE
Link Extension

### DIFF
--- a/lib/Twig/Extensions/Extension/Link.php
+++ b/lib/Twig/Extensions/Extension/Link.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class Twig_Extensions_Extension_Link extends Twig_Extension
+{
+    /**
+     * List of filters
+     *
+     * @return array
+     */
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter('link', array($this, 'createLink'), array(
+                'pre_escape' => 'html',
+                'is_safe' => array('html')
+            )),
+            new \Twig_SimpleFilter('linkTo', array($this, 'createNamedLink'), array(
+                'pre_escape' => 'html',
+                'is_safe' => array('html')
+            )),
+            new \Twig_SimpleFilter('mail', array($this, 'createMailTo'), array(
+                'pre_escape' => 'html',
+                'is_safe' => array('html')
+            )),
+            new \Twig_SimpleFilter('mailTo', array($this, 'createNamedMailTo'), array(
+                'pre_escape' => 'html',
+                'is_safe' => array('html')
+            ))
+        ];
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'link';
+    }
+
+    /**
+     * Create an html link from an url.
+     *
+     * @param string  $url        input
+     * @param array   $attributes html attributes e.g class, target, id
+     * @param boolean $withScheme let the scheme explicit or not
+     *
+     * @return string html formatted link
+     *
+     * @throws \Twig_Error_Runtime
+     */
+    public function createLink($url, array $attributes = array(), $withScheme = false)
+    {
+        if (!is_string($url)) {
+            throw new \Twig_Error_Runtime('Invalid argument passed to "link" filter, must be a string.');
+        }
+
+        $url = 'http' === substr($url, 0, 4) ? $url : 'http://' . $url;
+        $parts = explode('://', $url);
+        $link = $withScheme ? $url : $parts[1];
+        $attr = '';
+
+        foreach ($attributes as $attribute => $value) {
+            $attr .= ' ' . $attribute . '="' . $value . '"';
+        }
+
+        return '<a href="' . $url . '"' . $attr . '>' . $link . '</a>';
+    }
+
+    /**
+     * Create a named html link from an url
+     *
+     * @param string $url        input
+     * @param string $link       output name of the link
+     * @param array  $attributes html attributes e.g class, target, id
+     *
+     * @return string html output link
+     *
+     * @throws \Twig_Error_Runtime
+     */
+    public function createNamedLink($url, $link, array $attributes = array())
+    {
+        if (!is_string($url) || !is_string($link)) {
+            throw new \Twig_Error_Runtime('Invalid argument passed to "link" filter, must be a string.');
+        }
+
+        $url = 'http' === substr($url, 0, 4) ? $url : 'http://' . $url;
+        $attr = '';
+
+        foreach ($attributes as $attribute => $value) {
+            $attr .= ' ' . $attribute . '="' . $value . '"';
+        }
+
+        return '<a href="' . $url . '"' . $attr . '>' . $link . '</a>';
+    }
+
+    /**
+     * Create a mail link from an e-mail address
+     *
+     * @param string $mail       input e-mail
+     * @param array  $attributes html attributes e.g id, class
+     * @param string $subject    auto-complete subject of e-mail
+     * @param string $body       auto-complete body of e-mail
+     *
+     * @return string html output mailto link
+     *
+     * @throws \Twig_Error_Runtime
+     */
+    public function createMailTo($mail, array $attributes = array(), $subject = '', $body = '')
+    {
+        if (!is_string($mail)) {
+            throw new \Twig_Error_Runtime('Invalid argument passed to "linkTo" filter, must be a string.');
+        }
+
+        $attr = '';
+        $extra = '';
+        $params = array();
+
+        if ($subject) {
+            $params[] = 'subject=' . rawurlencode($subject);
+        }
+
+        if ($body) {
+            $params[] =  'body=' . rawurlencode($body);
+        }
+
+        if ($params) {
+            $extra .= '?' . implode('&', $params);
+        }
+
+        foreach ($attributes as $attribute => $value) {
+            $attr .= ' ' . $attribute . '="' . $value . '"';
+        }
+
+        return '<a href="mailto:' . $mail . $extra . '"' . $attr . '>' . $mail . '</a>';
+    }
+
+    /**
+     * Create a named mailto link from an e-mail
+     *
+     * @param string $mail       input e-mail
+     * @param string $link       input name of the link
+     * @param array  $attributes html attributes e.g id, class
+     * @param string $subject    auto-complete subject of e-mail
+     * @param string $body       auto-complete body of e-mail
+     *
+     * @return string html output mailto link
+     *
+     * @throws \Twig_Error_Runtime
+     */
+    public function createNamedMailTo($mail, $link, array $attributes = array(), $subject = '', $body = '')
+    {
+        if (!is_string($mail) || !is_string($link)) {
+            throw new \Twig_Error_Runtime('Invalid argument passed to "mail" filter, must be a string.');
+        }
+
+        $attr = '';
+        $extra = '';
+        $params = array();
+
+        if ($subject) {
+            $params[] = 'subject=' . rawurlencode($subject);
+        }
+
+        if ($body) {
+            $params[] =  'body=' . rawurlencode($body);
+        }
+
+        if ($params) {
+            $extra .= '?' . implode('&', $params);
+        }
+
+        foreach ($attributes as $attribute => $value) {
+            $attr .= ' ' . $attribute . '="' . $value . '"';
+        }
+
+        return '<a href="mailto:' . $mail . $extra . '"' . $attr . '>' . $link . '</a>';
+    }
+}

--- a/lib/Twig/Extensions/Extension/Link.php
+++ b/lib/Twig/Extensions/Extension/Link.php
@@ -75,7 +75,13 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
             $attr .= ' '.$attribute.'="'.$value.'"';
         }
 
-        return '<a href="'.urlencode($url).'"'.$attr.'>'.$link.'</a>';
+        $query = explode('?', $url, 2);
+
+        if (isset($query[1])) {
+            $url = $query[0].urlencode($query[1]);
+        }
+
+        return '<a href="'.$url.'"'.$attr.'>'.$link.'</a>';
     }
 
     /**
@@ -102,7 +108,13 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
             $attr .= ' '.$attribute.'="'.$value.'"';
         }
 
-        return '<a href="'.urlencode($url).'"'.$attr.'>'.$link.'</a>';
+        $parts = explode('?', $url, 2);
+
+        if (isset($parts[1])) {
+            $url = $parts[0].urlencode($parts[1]);
+        }
+
+        return '<a href="'.$url.'"'.$attr.'>'.$link.'</a>';
     }
 
     /**

--- a/lib/Twig/Extensions/Extension/Link.php
+++ b/lib/Twig/Extensions/Extension/Link.php
@@ -13,30 +13,30 @@
 class Twig_Extensions_Extension_Link extends Twig_Extension
 {
     /**
-     * List of filters
+     * List of filters.
      *
      * @return array
      */
     public function getFilters()
     {
-        return [
+        return array(
             new \Twig_SimpleFilter('link', array($this, 'createLink'), array(
                 'pre_escape' => 'html',
-                'is_safe' => array('html')
+                'is_safe' => array('html'),
             )),
             new \Twig_SimpleFilter('linkTo', array($this, 'createNamedLink'), array(
                 'pre_escape' => 'html',
-                'is_safe' => array('html')
+                'is_safe' => array('html'),
             )),
             new \Twig_SimpleFilter('mail', array($this, 'createMailTo'), array(
                 'pre_escape' => 'html',
-                'is_safe' => array('html')
+                'is_safe' => array('html'),
             )),
             new \Twig_SimpleFilter('mailTo', array($this, 'createNamedMailTo'), array(
                 'pre_escape' => 'html',
-                'is_safe' => array('html')
-            ))
-        ];
+                'is_safe' => array('html'),
+            )),
+        );
     }
 
     /**
@@ -52,9 +52,9 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
     /**
      * Create an html link from an url.
      *
-     * @param string  $url        input
-     * @param array   $attributes html attributes e.g class, target, id
-     * @param boolean $withScheme let the scheme explicit or not
+     * @param string $url        input
+     * @param array  $attributes html attributes e.g class, target, id
+     * @param bool   $withScheme let the scheme explicit or not
      *
      * @return string html formatted link
      *
@@ -66,20 +66,20 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
             throw new \Twig_Error_Runtime('Invalid argument passed to "link" filter, must be a string.');
         }
 
-        $url = 'http' === substr($url, 0, 4) ? $url : 'http://' . $url;
+        $url = 'http' === substr($url, 0, 4) ? $url : 'http://'.$url;
         $parts = explode('://', $url);
         $link = $withScheme ? $url : $parts[1];
         $attr = '';
 
         foreach ($attributes as $attribute => $value) {
-            $attr .= ' ' . $attribute . '="' . $value . '"';
+            $attr .= ' '.$attribute.'="'.$value.'"';
         }
 
-        return '<a href="' . urlencode($url) . '"' . $attr . '>' . $link . '</a>';
+        return '<a href="'.urlencode($url).'"'.$attr.'>'.$link.'</a>';
     }
 
     /**
-     * Create a named html link from an url
+     * Create a named html link from an url.
      *
      * @param string $url        input
      * @param string $link       output name of the link
@@ -95,14 +95,14 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
             throw new \Twig_Error_Runtime('Invalid argument passed to "link" filter, must be a string.');
         }
 
-        $url = 'http' === substr($url, 0, 4) ? $url : 'http://' . $url;
+        $url = 'http' === substr($url, 0, 4) ? $url : 'http://'.$url;
         $attr = '';
 
         foreach ($attributes as $attribute => $value) {
-            $attr .= ' ' . $attribute . '="' . $value . '"';
+            $attr .= ' '.$attribute.'="'.$value.'"';
         }
 
-        return '<a href="' . urlencode($url) . '"' . $attr . '>' . $link . '</a>';
+        return '<a href="'.urlencode($url).'"'.$attr.'>'.$link.'</a>';
     }
 
     /**
@@ -128,26 +128,26 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
         $params = array();
 
         if ($subject) {
-            $params[] = 'subject=' . rawurlencode($subject);
+            $params[] = 'subject='.rawurlencode($subject);
         }
 
         if ($body) {
-            $params[] =  'body=' . rawurlencode($body);
+            $params[] =  'body='.rawurlencode($body);
         }
 
         if ($params) {
-            $extra .= '?' . implode('&', $params);
+            $extra .= '?'.implode('&', $params);
         }
 
         foreach ($attributes as $attribute => $value) {
-            $attr .= ' ' . $attribute . '="' . $value . '"';
+            $attr .= ' '.$attribute.'="'.$value.'"';
         }
 
-        return '<a href="mailto:' . $mail . $extra . '"' . $attr . '>' . $mail . '</a>';
+        return '<a href="mailto:'.$mail.$extra.'"'.$attr.'>'.$mail.'</a>';
     }
 
     /**
-     * Create a named mailto link from an e-mail
+     * Create a named mailto link from an e-mail.
      *
      * @param string $mail       input e-mail
      * @param string $link       input name of the link
@@ -170,21 +170,21 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
         $params = array();
 
         if ($subject) {
-            $params[] = 'subject=' . rawurlencode($subject);
+            $params[] = 'subject='.rawurlencode($subject);
         }
 
         if ($body) {
-            $params[] =  'body=' . rawurlencode($body);
+            $params[] =  'body='.rawurlencode($body);
         }
 
         if ($params) {
-            $extra .= '?' . implode('&', $params);
+            $extra .= '?'.implode('&', $params);
         }
 
         foreach ($attributes as $attribute => $value) {
-            $attr .= ' ' . $attribute . '="' . $value . '"';
+            $attr .= ' '.$attribute.'="'.$value.'"';
         }
 
-        return '<a href="mailto:' . $mail . $extra . '"' . $attr . '>' . $link . '</a>';
+        return '<a href="mailto:'.$mail.$extra.'"'.$attr.'>'.$link.'</a>';
     }
 }

--- a/lib/Twig/Extensions/Extension/Link.php
+++ b/lib/Twig/Extensions/Extension/Link.php
@@ -106,7 +106,7 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
     }
 
     /**
-     * Create a mail link from an e-mail address
+     * Create a mail link from an e-mail address.
      *
      * @param string $mail       input e-mail
      * @param array  $attributes html attributes e.g id, class
@@ -132,7 +132,7 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
         }
 
         if ($body) {
-            $params[] =  'body='.rawurlencode($body);
+            $params[] = 'body='.rawurlencode($body);
         }
 
         if ($params) {
@@ -174,7 +174,7 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
         }
 
         if ($body) {
-            $params[] =  'body='.rawurlencode($body);
+            $params[] = 'body='.rawurlencode($body);
         }
 
         if ($params) {

--- a/lib/Twig/Extensions/Extension/Link.php
+++ b/lib/Twig/Extensions/Extension/Link.php
@@ -75,7 +75,7 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
             $attr .= ' ' . $attribute . '="' . $value . '"';
         }
 
-        return '<a href="' . $url . '"' . $attr . '>' . $link . '</a>';
+        return '<a href="' . urlencode($url) . '"' . $attr . '>' . $link . '</a>';
     }
 
     /**
@@ -102,7 +102,7 @@ class Twig_Extensions_Extension_Link extends Twig_Extension
             $attr .= ' ' . $attribute . '="' . $value . '"';
         }
 
-        return '<a href="' . $url . '"' . $attr . '>' . $link . '</a>';
+        return '<a href="' . urlencode($url) . '"' . $attr . '>' . $link . '</a>';
     }
 
     /**

--- a/test/Twig/Tests/Extension/LinkTest.php
+++ b/test/Twig/Tests/Extension/LinkTest.php
@@ -78,32 +78,32 @@ class Twig_Tests_Extension_LinkTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 'twig.sensiolabs.org/documentation', array(), false,
-                '<a href="http://twig.sensiolabs.org/documentation">twig.sensiolabs.org/documentation</a>'
+                '<a href="http://twig.sensiolabs.org/documentation">twig.sensiolabs.org/documentation</a>',
             ),
             array(
                 'https://github.com/twigphp/Twig', array(), false,
-                '<a href="https://github.com/twigphp/Twig">github.com/twigphp/Twig</a>'
+                '<a href="https://github.com/twigphp/Twig">github.com/twigphp/Twig</a>',
             ),
             array(
                 'twig.sensiolabs.org/documentation', array(), true,
-                '<a href="http://twig.sensiolabs.org/documentation">http://twig.sensiolabs.org/documentation</a>'
+                '<a href="http://twig.sensiolabs.org/documentation">http://twig.sensiolabs.org/documentation</a>',
             ),
             array(
                 'https://github.com/twigphp/Twig', array(), true,
-                '<a href="https://github.com/twigphp/Twig">https://github.com/twigphp/Twig</a>'
+                '<a href="https://github.com/twigphp/Twig">https://github.com/twigphp/Twig</a>',
             ),
             array(
                 'twig.sensiolabs.org/documentation', array('class' => 'mylinks', 'target' => '_blank'), false,
-                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">twig.sensiolabs.org/documentation</a>'
+                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">twig.sensiolabs.org/documentation</a>',
             ),
             array('https://github.com/twigphp/Twig', array('class' => 'mylinks', 'target' => '_blank'), false,
-                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">github.com/twigphp/Twig</a>'
+                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">github.com/twigphp/Twig</a>',
             ),
             array('twig.sensiolabs.org/documentation', array('class' => 'mylinks', 'target' => '_blank'), true,
-                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">http://twig.sensiolabs.org/documentation</a>'
+                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">http://twig.sensiolabs.org/documentation</a>',
             ),
             array('https://github.com/twigphp/Twig', array('class' => 'mylinks', 'target' => '_blank'), true,
-                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">https://github.com/twigphp/Twig</a>'
+                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">https://github.com/twigphp/Twig</a>',
             )
         );
     }
@@ -112,16 +112,16 @@ class Twig_Tests_Extension_LinkTest extends PHPUnit_Framework_TestCase
     {
         return array(
             array('twig.sensiolabs.org/documentation', 'Twig Documentation', array(),
-                '<a href="http://twig.sensiolabs.org/documentation">Twig Documentation</a>'
+                '<a href="http://twig.sensiolabs.org/documentation">Twig Documentation</a>',
             ),
             array('https://github.com/twigphp/Twig', 'Twig on GitHub', array(),
-                '<a href="https://github.com/twigphp/Twig">Twig on GitHub</a>'
+                '<a href="https://github.com/twigphp/Twig">Twig on GitHub</a>',
             ),
             array('twig.sensiolabs.org/documentation', 'Twig Documentation', array('class' => 'mylinks', 'target' => '_blank'),
-                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">Twig Documentation</a>'
+                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">Twig Documentation</a>',
             ),
             array('https://github.com/twigphp/Twig', 'Twig on GitHub', array('class' => 'mylinks', 'target' => '_blank'),
-                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">Twig on GitHub</a>'
+                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">Twig on GitHub</a>',
             )
         );
     }
@@ -131,23 +131,23 @@ class Twig_Tests_Extension_LinkTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 'fabien@symfony.com', array(), '', '',
-                '<a href="mailto:fabien@symfony.com">fabien@symfony.com</a>'
+                '<a href="mailto:fabien@symfony.com">fabien@symfony.com</a>',
             ),
             array(
                 'fabien@symfony.com', array('class' => 'mail-links'), '', '',
-                '<a href="mailto:fabien@symfony.com" class="mail-links">fabien@symfony.com</a>'
+                '<a href="mailto:fabien@symfony.com" class="mail-links">fabien@symfony.com</a>',
             ),
             array(
                 'fabien@symfony.com', array(), 'What about Twig ?', '',
-                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F">fabien@symfony.com</a>'
+                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F">fabien@symfony.com</a>',
             ),
             array(
                 'fabien@symfony.com', array(), '', 'Thank you for bringing PHP to a higher level for 10 years',
-                '<a href="mailto:fabien@symfony.com?body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years">fabien@symfony.com</a>'
+                '<a href="mailto:fabien@symfony.com?body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years">fabien@symfony.com</a>',
             ),
             array(
                 'fabien@symfony.com', array('class' => 'mail-links'), 'What about Twig ?', 'Thank you for bringing PHP to a higher level for 10 years',
-                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F&body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years" class="mail-links">fabien@symfony.com</a>'
+                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F&body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years" class="mail-links">fabien@symfony.com</a>',
             ),
         );
     }
@@ -157,23 +157,23 @@ class Twig_Tests_Extension_LinkTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 'fabien@symfony.com', 'Fabien', array(), '', '',
-                '<a href="mailto:fabien@symfony.com">Fabien</a>'
+                '<a href="mailto:fabien@symfony.com">Fabien</a>',
             ),
             array(
                 'fabien@symfony.com', 'Fabien', array('class' => 'mail-links'), '', '',
-                '<a href="mailto:fabien@symfony.com" class="mail-links">Fabien</a>'
+                '<a href="mailto:fabien@symfony.com" class="mail-links">Fabien</a>',
             ),
             array(
                 'fabien@symfony.com', 'Fabien', array(), 'What about Twig ?', '',
-                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F">Fabien</a>'
+                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F">Fabien</a>',
             ),
             array(
                 'fabien@symfony.com', 'Fabien', array(), '', 'Thank you for bringing PHP to a higher level for 10 years',
-                '<a href="mailto:fabien@symfony.com?body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years">Fabien</a>'
+                '<a href="mailto:fabien@symfony.com?body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years">Fabien</a>',
             ),
             array(
                 'fabien@symfony.com', 'Fabien', array('class' => 'mail-links'), 'What about Twig ?', 'Thank you for bringing PHP to a higher level for 10 years',
-                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F&body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years" class="mail-links">Fabien</a>'
+                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F&body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years" class="mail-links">Fabien</a>',
             ),
         );
     }

--- a/test/Twig/Tests/Extension/LinkTest.php
+++ b/test/Twig/Tests/Extension/LinkTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+require_once __DIR__.'/../../../../lib/Twig/Extensions/Extension/Link.php';
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class Twig_Tests_Extension_LinkTest extends PHPUnit_Framework_TestCase
+{
+    private $env;
+
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists('Twig_Extensions_Extension_Link')) {
+            self::markTestSkipped('Unable to find class Twig_Extensions_Extension_Link.');
+        }
+    }
+
+    public function setUp()
+    {
+        $coreExtension = $this->getMock('Twig_Extension_Core');
+
+        $this->env = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
+        $this->env
+            ->expects($this->any())
+            ->method('getExtension')
+            ->with('core')
+            ->will($this->returnValue($coreExtension))
+        ;
+    }
+
+    /**
+     * @dataProvider getLinks()
+     */
+    public function testCreateLink($url, $attributes, $withScheme, $expectedOutput)
+    {
+        $extension = new Twig_Extensions_Extension_Link();
+        $this->assertEquals($expectedOutput, $extension->createLink($url, $attributes, $withScheme));
+    }
+
+    /**
+     * @dataProvider getNamedLinks()
+     */
+    public function testCreateNamedLink($url, $link, $attributes, $expectedOutput)
+    {
+        $extension = new Twig_Extensions_Extension_Link();
+        $this->assertEquals($expectedOutput, $extension->createNamedLink($url, $link, $attributes));
+    }
+
+    /**
+     * @dataProvider getMails()
+     */
+    public function testCreateMailTo($mail, $attributes, $subject, $body, $expectedOutput)
+    {
+        $extension = new Twig_Extensions_Extension_Link();
+        $this->assertEquals($expectedOutput, $extension->createMailTo($mail, $attributes, $subject, $body));
+    }
+
+    /**
+     * @dataProvider getNamedMails()
+     */
+    public function testCreateNamedMailTo($mail, $name, $attributes, $subject, $body, $expectedOutput)
+    {
+        $extension = new Twig_Extensions_Extension_Link();
+        $this->assertEquals($expectedOutput, $extension->createNamedMailTo($mail, $name, $attributes, $subject, $body));
+    }
+
+    public function getLinks()
+    {
+        return array(
+            array(
+                'twig.sensiolabs.org/documentation', array(), false,
+                '<a href="http://twig.sensiolabs.org/documentation">twig.sensiolabs.org/documentation</a>'
+            ),
+            array(
+                'https://github.com/twigphp/Twig', array(), false,
+                '<a href="https://github.com/twigphp/Twig">github.com/twigphp/Twig</a>'
+            ),
+            array(
+                'twig.sensiolabs.org/documentation', array(), true,
+                '<a href="http://twig.sensiolabs.org/documentation">http://twig.sensiolabs.org/documentation</a>'
+            ),
+            array(
+                'https://github.com/twigphp/Twig', array(), true,
+                '<a href="https://github.com/twigphp/Twig">https://github.com/twigphp/Twig</a>'
+            ),
+            array(
+                'twig.sensiolabs.org/documentation', array('class' => 'mylinks', 'target' => '_blank'), false,
+                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">twig.sensiolabs.org/documentation</a>'
+            ),
+            array('https://github.com/twigphp/Twig', array('class' => 'mylinks', 'target' => '_blank'), false,
+                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">github.com/twigphp/Twig</a>'
+            ),
+            array('twig.sensiolabs.org/documentation', array('class' => 'mylinks', 'target' => '_blank'), true,
+                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">http://twig.sensiolabs.org/documentation</a>'
+            ),
+            array('https://github.com/twigphp/Twig', array('class' => 'mylinks', 'target' => '_blank'), true,
+                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">https://github.com/twigphp/Twig</a>'
+            )
+        );
+    }
+
+    public function getNamedLinks()
+    {
+        return array(
+            array('twig.sensiolabs.org/documentation', 'Twig Documentation', array(),
+                '<a href="http://twig.sensiolabs.org/documentation">Twig Documentation</a>'
+            ),
+            array('https://github.com/twigphp/Twig', 'Twig on GitHub', array(),
+                '<a href="https://github.com/twigphp/Twig">Twig on GitHub</a>'
+            ),
+            array('twig.sensiolabs.org/documentation', 'Twig Documentation', array('class' => 'mylinks', 'target' => '_blank'),
+                '<a href="http://twig.sensiolabs.org/documentation" class="mylinks" target="_blank">Twig Documentation</a>'
+            ),
+            array('https://github.com/twigphp/Twig', 'Twig on GitHub', array('class' => 'mylinks', 'target' => '_blank'),
+                '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">Twig on GitHub</a>'
+            )
+        );
+    }
+
+    public function getMails()
+    {
+        return array(
+            array(
+                'fabien@symfony.com', array(), '', '',
+                '<a href="mailto:fabien@symfony.com">fabien@symfony.com</a>'
+            ),
+            array(
+                'fabien@symfony.com', array('class' => 'mail-links'), '', '',
+                '<a href="mailto:fabien@symfony.com" class="mail-links">fabien@symfony.com</a>'
+            ),
+            array(
+                'fabien@symfony.com', array(), 'What about Twig ?', '',
+                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F">fabien@symfony.com</a>'
+            ),
+            array(
+                'fabien@symfony.com', array(), '', 'Thank you for bringing PHP to a higher level for 10 years',
+                '<a href="mailto:fabien@symfony.com?body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years">fabien@symfony.com</a>'
+            ),
+            array(
+                'fabien@symfony.com', array('class' => 'mail-links'), 'What about Twig ?', 'Thank you for bringing PHP to a higher level for 10 years',
+                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F&body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years" class="mail-links">fabien@symfony.com</a>'
+            ),
+        );
+    }
+
+    public function getNamedMails()
+    {
+        return array(
+            array(
+                'fabien@symfony.com', 'Fabien', array(), '', '',
+                '<a href="mailto:fabien@symfony.com">Fabien</a>'
+            ),
+            array(
+                'fabien@symfony.com', 'Fabien', array('class' => 'mail-links'), '', '',
+                '<a href="mailto:fabien@symfony.com" class="mail-links">Fabien</a>'
+            ),
+            array(
+                'fabien@symfony.com', 'Fabien', array(), 'What about Twig ?', '',
+                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F">Fabien</a>'
+            ),
+            array(
+                'fabien@symfony.com', 'Fabien', array(), '', 'Thank you for bringing PHP to a higher level for 10 years',
+                '<a href="mailto:fabien@symfony.com?body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years">Fabien</a>'
+            ),
+            array(
+                'fabien@symfony.com', 'Fabien', array('class' => 'mail-links'), 'What about Twig ?', 'Thank you for bringing PHP to a higher level for 10 years',
+                '<a href="mailto:fabien@symfony.com?subject=What%20about%20Twig%20%3F&body=Thank%20you%20for%20bringing%20PHP%20to%20a%20higher%20level%20for%2010%20years" class="mail-links">Fabien</a>'
+            ),
+        );
+    }
+}

--- a/test/Twig/Tests/Extension/LinkTest.php
+++ b/test/Twig/Tests/Extension/LinkTest.php
@@ -104,7 +104,7 @@ class Twig_Tests_Extension_LinkTest extends PHPUnit_Framework_TestCase
             ),
             array('https://github.com/twigphp/Twig', array('class' => 'mylinks', 'target' => '_blank'), true,
                 '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">https://github.com/twigphp/Twig</a>',
-            )
+            ),
         );
     }
 
@@ -122,7 +122,7 @@ class Twig_Tests_Extension_LinkTest extends PHPUnit_Framework_TestCase
             ),
             array('https://github.com/twigphp/Twig', 'Twig on GitHub', array('class' => 'mylinks', 'target' => '_blank'),
                 '<a href="https://github.com/twigphp/Twig" class="mylinks" target="_blank">Twig on GitHub</a>',
-            )
+            ),
         );
     }
 


### PR DESCRIPTION
Add filters : `link`, `linkTo`, `mail` and `mailTo`, example :
```twig
{{ url|linkTo('Name') }}
```
=>
```html
<a href="urlencoded_url">Name</a>
```
____

usage :
```twig
{{ 'twig.sensiolabs.org/documentation'|link }}
```
=>
```html
<a href="http://twig.sensiolabs.org/documentation">twig.sensiolabs.org/documentation</a>`
```
The scheme "http" or "https" is escape by default when rendered in html
but you can change it by passing `true` as third argument, second argument is an array of html attributes :
```twig
{{ 'https://symfony.com'|link({'class": special-link", 'target': '_blank'}, true) }}
```
=>
```html
<a href ="https://symfony.com" class="special-link" target="_blank">https://symfony.com</a>
```
______

use `linkTo` to pass a name as first argument and attributes in second, no more :
```twig
{{ sf.url|linkTo(sf.title, {'data-version': sf.version}) }}
```
=>
```html
<a href="https://symfony.com" data-version="3">Symfony, High Performance PHP Framework for Web Application</a>
```
_____
use `mail` and `mailTo` the same way to get a mail link :
```twig
 {{ user.mail|mailTo(user.name) }}
```
=>
```html
<a href="mailto:user@email.com">User Name</a>
```
____
`mail`& `mailTo` accept two extra arguments : `$subject` and `$body`
```twig
{{ user.email|mail({}, 'This a subject!', 'This is some body + whatever I want & more') }}
```
=>
```html
<a href="mailto:someone@email.com?subject=rawurlencoded_subject&body=rawurlencoded_body">Someone</a>
```