### PR TITLE
Document that Intl formats number and currency too

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,7 +30,7 @@ command line:
 * :doc:`I18n <i18n>`: Adds internationalization support via the ``gettext``
   library;
 
-* :doc:`Intl <intl>`: Adds a filter for localization of ``DateTime`` objects;
+* :doc:`Intl <intl>`: Adds a filter for localization of ``DateTime`` objects, numbers and currency;
 
 * :doc:`Array <array>`: Provides useful filters for array manipulation;
 


### PR DESCRIPTION
The index only states that the Intl extension formats DateTime objects.  In fact, it also formats numbers and currency.