### PR TITLE
Fixed pluralization

### DIFF
--- a/lib/Twig/Extensions/Extension/Date.php
+++ b/lib/Twig/Extensions/Extension/Date.php
@@ -101,7 +101,7 @@ class Twig_Extensions_Extension_Date extends Twig_Extension
             return $this->translator->transChoice($id, $count, array('%count%' => $count), 'date');
         }
 
-        if ($count > 1) {
+        if (1 !== $count) {
             $unit .= 's';
         }
 


### PR DESCRIPTION
Pluralization should be used also for *0 seconds*, *0 minutes*, etc.