### PR TITLE
Override the gettext functions with anything with the same argument signature

### DIFF
--- a/lib/Twig/Extensions/Extension/I18n.php
+++ b/lib/Twig/Extensions/Extension/I18n.php
@@ -28,7 +28,7 @@ class Twig_Extensions_Extension_I18n extends Twig_Extension
      */
     public function getTokenParsers()
     {
-        return array(new Twig_Extensions_TokenParser_Trans($singularFunc = $this->singularFunc, $pluralFunc = $this->pluralFunc));
+        return array(new Twig_Extensions_TokenParser_Trans($this->singularFunc, $this->pluralFunc));
     }
 
     /**

--- a/lib/Twig/Extensions/Extension/I18n.php
+++ b/lib/Twig/Extensions/Extension/I18n.php
@@ -10,6 +10,17 @@
  */
 class Twig_Extensions_Extension_I18n extends Twig_Extension
 {
+    /** @var string */
+    private $singularFunc;
+
+    /** @var string */
+    private $pluralFunc;
+
+    public function __construct($singularFunc = 'gettext', $pluralFunc = 'ngettext') {
+        $this->singularFunc = $singularFunc;
+        $this->pluralFunc = $pluralFunc;
+    }
+
     /**
      * Returns the token parser instances to add to the existing list.
      *
@@ -17,7 +28,7 @@ class Twig_Extensions_Extension_I18n extends Twig_Extension
      */
     public function getTokenParsers()
     {
-        return array(new Twig_Extensions_TokenParser_Trans());
+        return array(new Twig_Extensions_TokenParser_Trans($singularFunc = $this->singularFunc, $pluralFunc = $this->pluralFunc));
     }
 
     /**

--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -16,9 +16,11 @@
  */
 class Twig_Extensions_Node_Trans extends Twig_Node
 {
-    public function __construct(Twig_Node $body, Twig_Node $plural = null, Twig_Node_Expression $count = null, Twig_Node $notes = null, $lineno, $tag = null)
+    public function __construct(Twig_Node $body, Twig_Node $plural = null, Twig_Node_Expression $count = null, Twig_Node $notes = null, $lineno, $tag = null, $singularFunc = 'gettext', $pluralFunc = 'ngettext')
     {
         parent::__construct(array('count' => $count, 'body' => $body, 'plural' => $plural, 'notes' => $notes), array(), $lineno, $tag);
+        $this->singularFunc = $singularFunc;
+        $this->pluralFunc = $pluralFunc;
     }
 
     /**
@@ -38,7 +40,7 @@ class Twig_Extensions_Node_Trans extends Twig_Node
             $vars = array_merge($vars, $vars1);
         }
 
-        $function = null === $this->getNode('plural') ? 'gettext' : 'ngettext';
+        $function = null === $this->getNode('plural') ? $this->singularFunc : $this->pluralFunc;
 
         if (null !== $notes = $this->getNode('notes')) {
             $message = trim($notes->getAttribute('data'));

--- a/lib/Twig/Extensions/TokenParser/Trans.php
+++ b/lib/Twig/Extensions/TokenParser/Trans.php
@@ -10,6 +10,20 @@
  */
 class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
 {
+
+    /**
+     * Constructor, can override translation functions
+     *
+     * @param string $singularFunc The name of a function with the interface of gettext
+     * @param string $pluralFunc   The name of a function with the interface of ngettext
+     */
+    public function __construct($singularFunc = 'gettext', $pluralFunc = 'ngettext')
+    {
+        $this->singularFunc = $singularFunc;
+        $this->pluralFunc = $pluralFunc;
+    }
+
+
     /**
      * Parses a token and returns a node.
      *
@@ -51,7 +65,7 @@ class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
 
         $this->checkTransString($body, $lineno);
 
-        return new Twig_Extensions_Node_Trans($body, $plural, $count, $notes, $lineno, $this->getTag());
+        return new Twig_Extensions_Node_Trans($body, $plural, $count, $notes, $lineno, $this->getTag(), $this->singularFunc, $this->pluralFunc);
     }
 
     public function decideForFork(Twig_Token $token)

--- a/lib/Twig/Extensions/TokenParser/Trans.php
+++ b/lib/Twig/Extensions/TokenParser/Trans.php
@@ -10,9 +10,8 @@
  */
 class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
 {
-
     /**
-     * Constructor, can override translation functions
+     * Constructor, can override translation functions.
      *
      * @param string $singularFunc The name of a function with the interface of gettext
      * @param string $pluralFunc   The name of a function with the interface of ngettext
@@ -22,7 +21,6 @@ class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
         $this->singularFunc = $singularFunc;
         $this->pluralFunc = $pluralFunc;
     }
-
 
     /**
      * Parses a token and returns a node.


### PR DESCRIPTION
This is a slightly smaller change than #160, and would also close #152.