### PR TITLE
Fixed test for "getMock" deprecation warning and some xdebug options.

### DIFF
--- a/lib/Twig/Extensions/Extension/I18n.php
+++ b/lib/Twig/Extensions/Extension/I18n.php
@@ -10,6 +10,70 @@
  */
 class Twig_Extensions_Extension_I18n extends Twig_Extension
 {
+    private $delimiters = array();
+
+    /**
+     * Constructor for I18n Extension
+     *
+     * @param array     $options    Set of options for this Extension instance.
+     *
+     * Available options:
+     *
+     *  * delimiters:               When set, it defines the delimiters for
+     *    [default: "{{|}}"]        field placeholders. Can be a string of
+     *                              length 2 (Eg: "%%", "{}", "||") or a
+     *                              string containing the mask "%s" which marks
+     *                              the position of the field (Eg: "{{|}}",
+     *                              "[|]").
+     */
+    public function __construct($options = array())
+    {
+        $options = array_merge(array(
+            'delimiters' => '%%'
+        ), $options);
+
+        $this->delimiters = $this->parseDelimiters($options['delimiters']);
+    }
+
+    /**
+     * Returns the delimiters array for field placeholders in strings
+     */
+    public function getDelimiters()
+    {
+        return $this->delimiters;
+    }
+
+    /**
+     * Parses the $dels to configure our "delimiters" property.
+     * Three syntax for delimiter patterns are allowed:
+     *
+     *  1) String pattern including a "|" character that marks the position of
+     *     the variable name. Eg: "%|%", "start|end".
+     *
+     *  2) String of an even length: Delimiters are constructed with the first
+     *     half and the second half. Eg: "{{}}" => ["{{", "}}"]
+     *
+     *  3) Array of exactly 2 items: Delimiters are constructed from the array
+     *     itself. No further checking is done, but converted to strings.
+     */
+    private function parseDelimiters($dels)
+    {
+        if (is_string($dels) && (strpos($dels, '|') !== false)) {
+            return array_values(array_filter(array_map('trim', explode('|', $dels))));
+        }
+
+        if (is_string($dels) && !(strlen($dels) % 2)) {
+            $mid = ceil(strlen($dels) / 2);
+            return array(substr($dels, 0, $mid), substr($dels, $mid));
+        }
+
+        if (is_array($dels) && (count($dels) == 2)) {
+            return array((string)$dels[0], (string)$dels[1]);
+        }
+
+        throw new Twig_Error('Pattern "'.$dels.'" not allowed as delimiters.');
+    }
+
     /**
      * Returns the token parser instances to add to the existing list.
      *

--- a/test/Twig/Tests/Extension/DateTest.php
+++ b/test/Twig/Tests/Extension/DateTest.php
@@ -31,7 +31,7 @@ class Twig_Tests_Extension_DateTest extends PHPUnit_Framework_TestCase
     {
         $timezone = new DateTimeZone(date_default_timezone_get());
 
-        $coreExtension = $this->getMock('Twig_Extension_Core');
+        $coreExtension = $this->getMockBuilder('Twig_Extension_Core')->getMock();
         $coreExtension
             ->expects($this->any())
             ->method('getTimezone')
@@ -81,7 +81,7 @@ class Twig_Tests_Extension_DateTest extends PHPUnit_Framework_TestCase
      */
     public function testDiffCanReturnTranslatableString($expected, $translated, $date, $now)
     {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
         $translator
             ->expects($this->once())
             ->method('transChoice')

--- a/test/Twig/Tests/Extension/I18nTest.php
+++ b/test/Twig/Tests/Extension/I18nTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Twig_Tests_Extension_I18nTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider getDelimitersTests
+     */
+    public function testDelimiters($pattern, $expected, $exception = null)
+    {
+        if ($exception) $this->setExpectedException($exception);
+
+        $ext = new Twig_Extensions_Extension_I18n(array('delimiters' => $pattern));
+        $this->assertSame($expected, $ext->getDelimiters());
+    }
+
+    public function getDelimitersTests()
+    {
+        return array(
+            array('{}', array('{', '}')),
+            array('[]', array('[', ']')),
+            array('[|]', array('[', ']')),
+            array('[[|]]', array('[[', ']]')),
+            array('{{|}}', array('{{', '}}')),
+            array('{{||||}}', array('{{', '}}')),
+            array('{{}}', array('{{', '}}')),
+
+            array('abcde', null, 'Twig_Error'),
+            array('abcd', array('ab', 'cd')),
+            array('{{}', null, 'Twig_Error'),
+
+            // Some edge cases
+            array('{{|||}}||||', array('{{', '}}')),
+            array('||||{{|||}}', array('{{', '}}')),
+            array('||{{|||}}||', array('{{', '}}')),
+            array('|  |{{ | | |}} | |', array('{{', '}}')),
+        );
+    }
+
+}
+

--- a/test/Twig/Tests/Node/TransTest.php
+++ b/test/Twig/Tests/Node/TransTest.php
@@ -108,6 +108,17 @@ class Twig_Tests_Node_TransTest extends Twig_Test_NodeTestCase
         $node = new Twig_Extensions_Node_Trans($body, $plural, $count, $notes, 0);
         $tests[] = array($node, "// notes: Notes for translators\n".'echo strtr(ngettext("There is 1 pending task", "There are %count% pending tasks", abs(5)), array("%count%" => abs(5), ));');
 
+        // with environment options
+        $test_env = new Twig_Environment(new Twig_Loader_Array(array()));
+        $test_env->addExtension(new Twig_Extensions_Extension_I18n(array('delimiters' => '[[]]')));
+        $body = new Twig_Node(array(
+            new Twig_Node_Text('Hey ', 0),
+            new Twig_Node_Print(new Twig_Node_Expression_Name('name', 0), 0),
+            new Twig_Node_Text(', I have one apple', 0),
+        ), array(), 0);
+        $node = new Twig_Extensions_Node_Trans($body, null, null, null, 0);
+        $tests[] = array($node, sprintf('echo strtr(gettext("Hey [[name]], I have one apple"), array("[[name]]" => %s, ));', $this->getVariableGetter('name')), $test_env);
+
         return $tests;
     }
 }

--- a/test/Twig/Tests/grammarTest.php
+++ b/test/Twig/Tests/grammarTest.php
@@ -14,6 +14,22 @@ require_once dirname(__FILE__).'/SimpleTokenParser.php';
 class grammarTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * Reset "xdebug.overload_var_dump" if set to 2 to avoid filename output.
+     * Reset "xdebug.cli_color" if set to On outputs ASCII color codes.
+     */
+    public static function setUpBeforeClass()
+    {
+        if (extension_loaded("xdebug")) {
+            if (ini_get("xdebug.overload_var_dump") == 2) {
+                ini_set("xdebug.overload_var_dump", 1);
+            }
+            if (ini_get("xdebug.cli_color")) {
+                ini_set("xdebug.cli_color", 0);
+            }
+        }
+    }
+
+    /**
      * @dataProvider getTests
      */
     public function testGrammar($tag, $grammar, $template, $output, $exception)

--- a/test/Twig/Tests/grammarTest.php
+++ b/test/Twig/Tests/grammarTest.php
@@ -19,12 +19,12 @@ class grammarTest extends PHPUnit_Framework_TestCase
      */
     public static function setUpBeforeClass()
     {
-        if (extension_loaded("xdebug")) {
-            if (ini_get("xdebug.overload_var_dump") == 2) {
-                ini_set("xdebug.overload_var_dump", 1);
+        if (extension_loaded('xdebug')) {
+            if (ini_get('xdebug.overload_var_dump') == 2) {
+                ini_set('xdebug.overload_var_dump', 1);
             }
-            if (ini_get("xdebug.cli_color")) {
-                ini_set("xdebug.cli_color", 0);
+            if (ini_get('xdebug.cli_color')) {
+                ini_set('xdebug.cli_color', 0);
             }
         }
     }


### PR DESCRIPTION
* PHPUnit 5.4 deprecates `PHPUnit_Framework_TestCase::getMock()`:

> The `PHPUnit_Framework_TestCase::getMock()` method has been deprecated. Please use `PHPUnit_Framework_TestCase::createMock()` or `PHPUnit_Framework_TestCase::getMockBuilder()` instead.

* Some options of PHP xDebug interferes with tests.  `test/Twig/Tests/grammarTest.php` fails with `debug.overload_var_dump` set to 2 and `xdebug.cli_color` set to True.
