### PR TITLE
added localized number pattern filter

### DIFF
--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -65,6 +65,19 @@ representating the number.
     Internally, Twig uses the PHP `NumberFormatter::create()`_ function for
     the number.
 
+``localizednumberpattern``
+--------------------------
+
+Use the ``localizednumberpattern`` filter to format numbers using a pattern.
+
+.. code-block:: jinja
+
+    {{ product.rating|localizednumberpattern('0.0') }}
+
+.. note::
+
+    Prefer using ``localizednumber`` since it will localize the pattern.
+
 Arguments
 ~~~~~~~~~
 

--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -28,6 +28,7 @@ class Twig_Extensions_Extension_Intl extends Twig_Extension
         return array(
             new Twig_SimpleFilter('localizeddate', 'twig_localized_date_filter', array('needs_environment' => true)),
             new Twig_SimpleFilter('localizednumber', 'twig_localized_number_filter'),
+            new Twig_SimpleFilter('localizednumberpattern', 'twig_localized_number_pattern_filter'),
             new Twig_SimpleFilter('localizedcurrency', 'twig_localized_currency_filter'),
         );
     }
@@ -78,6 +79,25 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
     );
 
     $formatter = twig_get_number_formatter($locale, $style);
+
+    if (!isset($typeValues[$type])) {
+        throw new Twig_Error_Syntax(sprintf('The type "%s" does not exist. Known types are: "%s"', $type, implode('", "', array_keys($typeValues))));
+    }
+
+    return $formatter->format($number, $typeValues[$type]);
+}
+
+function twig_localized_number_pattern_filter($number, $pattern, $type = 'default', $locale = null)
+{
+    static $typeValues = array(
+        'default' => NumberFormatter::TYPE_DEFAULT,
+        'int32' => NumberFormatter::TYPE_INT32,
+        'int64' => NumberFormatter::TYPE_INT64,
+        'double' => NumberFormatter::TYPE_DOUBLE,
+        'currency' => NumberFormatter::TYPE_CURRENCY,
+    );
+
+    $formatter = NumberFormatter::create($locale, NumberFormatter::PATTERN_DECIMAL, $pattern);
 
     if (!isset($typeValues[$type])) {
         throw new Twig_Error_Syntax(sprintf('The type "%s" does not exist. Known types are: "%s"', $type, implode('", "', array_keys($typeValues))));


### PR DESCRIPTION
I needed a more specific pattern while outputting a number.
The filter name might be a little long though.

``` jinja
{{ 1.0|localizednumberpattern('00.0') }} {# will output 01.0 #}
{{ 12.34|localizednumberpattern('00.0') }} {# will output 12.3 #}
```
