### PR TITLE
Node\Trans: Clean up whitespace in message IDs.

### DIFF
--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -140,6 +140,8 @@ class Twig_Extensions_Node_Trans extends Twig_Node
             $msg = $body->getAttribute('data');
         }
 
-        return array(new Twig_Node(array(new Twig_Node_Expression_Constant(trim($msg), $body->getLine()))), $vars);
+        $msg = str_replace(array("\n", "\r"), " ", trim($msg));
+        $msg = preg_replace('/\s+/u', " ", $msg);
+        return array(new Twig_Node(array(new Twig_Node_Expression_Constant($msg, $body->getLine()))), $vars);
     }
 }


### PR DESCRIPTION
Text in trans nodes spanning multiple lines would lead to different
message IDs depending on indentation of the trans node. In order to
get reproducible message IDs, newlines are converted to single space
and consecutive whitespace due to indentation is replaced with a
single space.

Consider this node:
```
{% trans %}
    Foo
    Bar
{% endtrans %}
```
This would lead to a message ID with four spaces between `Foo` and `Bar`. Some nesting levels deeper it might look like this:
```
            {% trans %}
                Foo
                Bar
            {% endtrans %}
```
And it would give me a message ID with 16 spaces between `Foo` and `Bar`. I've then got two message IDs to translate. I consider this undesireable.