### PR TITLE
DisplayCallGraphTemplate: a visual way to show the display graph

### DIFF
--- a/lib/Twig/Extensions/Template/DisplayCallGraphTemplate.php
+++ b/lib/Twig/Extensions/Template/DisplayCallGraphTemplate.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) 2010 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Displays the call graph (templates names and block names) in a visual way directly in the generated HTML.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+abstract class Twig_Extensions_Template_DisplayCallGraphTemplate extends Twig_Template
+{
+    /**
+     * @var string[]
+     */
+    protected $templateBlackList = array();
+
+    /**
+     * @var string[]
+     */
+    protected $blockBlackList = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function display(array $context, array $blocks = array())
+    {
+        if (!$this->isTemplateEnabled()) {
+            parent::display($context, $blocks);
+
+            return;
+        }
+
+        echo sprintf($this->getTemplateStart(), htmlspecialchars($this->getTemplateName()));
+        parent::display($context, $blocks);
+        echo $this->getTemplateEnd();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function displayBlock($name, array $context, array $blocks = array(), $useBlocks = true)
+    {
+        if (!$this->isTemplateEnabled() || !$this->isBlockEnabled($name)) {
+            parent::displayBlock($name, $context, $blocks, $useBlocks);
+
+            return;
+        }
+
+        echo sprintf($this->getBlockStart(), htmlspecialchars($name));
+        parent::displayBlock($name, $context, $blocks, $useBlocks);
+        echo $this->getBlockEnd();
+    }
+
+    /**
+     * Checks if the call graph must be displayed for this template.
+     *
+     * @return bool
+     */
+    protected function isTemplateEnabled()
+    {
+        foreach ($this->templateBlackList as $prefix) {
+            if (false !== strpos($this->getTemplateName(), $prefix)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks if the call graph must be displayed for the given block.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    protected function isBlockEnabled($name)
+    {
+        foreach ($this->blockBlackList as $prefix) {
+            if (false !== strpos($name, $prefix)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Delimiter for the start of a template.
+     *
+     * @return string
+     */
+    protected function getTemplateStart()
+    {
+        return '<div style="border: 1px solid rgba(240, 181, 24, 0.3); margin: 5px;"><span style="background-color: rgba(240, 181, 24, 0.3); color: black; font-family: monospace;">Template "%s"</span>';
+    }
+
+    /**
+     * Delimiter for the end of a template.
+     *
+     * @return string
+     */
+    protected function getTemplateEnd()
+    {
+        return '</div>';
+    }
+
+    /**
+     * Delimiter for the start of a block.
+     *
+     * @return string
+     */
+    protected function getBlockStart()
+    {
+        return '<div style="border: 1px solid rgba(100, 189, 99, 0.2); margin: 5px;"><span style="background-color: rgba(100, 189, 99, 0.2); color: black; font-family: monospace;">Block "%s"</span>';
+    }
+
+    /**
+     * Delimiter for the end of a block.
+     *
+     * @return string
+     */
+    protected function getBlockEnd()
+    {
+        return '</div>';
+    }
+}

--- a/lib/Twig/Extensions/Template/DisplayCallGraphTemplate.php
+++ b/lib/Twig/Extensions/Template/DisplayCallGraphTemplate.php
@@ -17,16 +17,6 @@
 abstract class Twig_Extensions_Template_DisplayCallGraphTemplate extends Twig_Template
 {
     /**
-     * @var string[]
-     */
-    protected $templateBlackList = array();
-
-    /**
-     * @var string[]
-     */
-    protected $blockBlackList = array();
-
-    /**
      * {@inheritdoc}
      */
     public function display(array $context, array $blocks = array())
@@ -65,7 +55,7 @@ abstract class Twig_Extensions_Template_DisplayCallGraphTemplate extends Twig_Te
      */
     protected function isTemplateEnabled()
     {
-        foreach ($this->templateBlackList as $prefix) {
+        foreach ($this->getTemplateBlackList() as $prefix) {
             if (false !== strpos($this->getTemplateName(), $prefix)) {
                 return false;
             }
@@ -83,7 +73,7 @@ abstract class Twig_Extensions_Template_DisplayCallGraphTemplate extends Twig_Te
      */
     protected function isBlockEnabled($name)
     {
-        foreach ($this->blockBlackList as $prefix) {
+        foreach ($this->getBlockBlackList() as $prefix) {
             if (false !== strpos($name, $prefix)) {
                 return false;
             }
@@ -113,6 +103,16 @@ abstract class Twig_Extensions_Template_DisplayCallGraphTemplate extends Twig_Te
     }
 
     /**
+     * The list of black listed templates.
+     *
+     * @return array
+     */
+    protected function getTemplateBlackList()
+    {
+        return array();
+    }
+
+    /**
      * Delimiter for the start of a block.
      *
      * @return string
@@ -130,5 +130,15 @@ abstract class Twig_Extensions_Template_DisplayCallGraphTemplate extends Twig_Te
     protected function getBlockEnd()
     {
         return '</div>';
+    }
+
+    /**
+     * The list of black listed blocks.
+     *
+     * @return array
+     */
+    protected function getBlockBlackList()
+    {
+        return array();
     }
 }


### PR DESCRIPTION
Follows twigphp/Twig#1942.

A picture is worth a thousand words:

![capture d ecran 2015-12-17 a 16 27 55](https://cloud.githubusercontent.com/assets/57224/11875470/0be621da-a4e5-11e5-881b-b4cc42af37d8.png)

To enable it:

``` php
$twig = new Twig_Environment(null, array('base_template_class' => 'Twig_Extensions_Template_DisplayCallGraphTemplate');
```

Using Symfony:

``` yaml
# app/config/config_dev.yml

twig:
    base_template_class: Twig_Extensions_Template_DisplayCallGraphTemplate
```

The color scheme and the font are the same than in the Symfony Profiler. 

/cc @xavierleune @cssyren
