### PR TITLE
Incorrect twig version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "twig/twig": "~1.20|~2.0"
+        "twig/twig": "~1.27|~2.0"
     },
     "require-dev": {
         "symfony/translation": "~2.3"


### PR DESCRIPTION
Classes are making calls to getTemplateLine() on Twig_Node class which doesn't exist until twig version 1.27, and is previously called getLine() in 1.20-1.26

eg: Trans.php line 143