### PR TITLE
Make wordwrap consistent

### DIFF
--- a/test/Twig/Tests/Extension/TextTest.php
+++ b/test/Twig/Tests/Extension/TextTest.php
@@ -46,4 +46,23 @@ class Twig_Tests_Extension_TextTest extends PHPUnit_Framework_TestCase
             array('This is a very long sentence.', 23, true, '...', 'This is a very long sentence.'),
         );
     }
+
+    /**
+     * @dataProvider getWordWrapTestData
+     */
+    public function testWordWrap($input, $length, $preserve, $separator, $expectedOutput)
+    {
+        $output = twig_wordwrap_filter($this->env, $input, $length, $separator, $preserve);
+
+        $this->assertEquals($expectedOutput, $output);
+    }
+
+    public function getWordWrapTestData()
+    {
+        return array(
+            array('This is a very long sentence.', 10, false, '___', 'This is a___very long___sentence.'),
+            array('This is a very long sentence.', 3, false, '___', 'Thi___s___is___a___ver___y___lon___g___sen___ten___ce.'),
+            array('This is a very long sentence.', 3, true, '___', 'This___is___a___very___long___sentence.'),
+        );
+    }
 }


### PR DESCRIPTION
As noted in issue #179 the output of word wrap extension depends on the installed **mbstring** extension and if it is installed the `preserve` option is broken.

I am not sure that the output is 100% as intended (there are some edge cases with trimmed spaces), but at least it is consistent with the output of the built in `wordwrap` function for the given examples.

There are also a couple of tests included, but to make sure that the output is the same one has to manually negate the if clause located [here](https://github.com/twigphp/Twig-extensions/blob/bf98d6c99d83620de0938fef76ae17aa71b052a0/lib/Twig/Extensions/Extension/Text.php#L37)  between phpunit runs (or toggle the **mbstring** extension between runs).

**Important!** I adapted [this alghorithm](http://stackoverflow.com/a/4988494) so I am not sure if this has any consequences to the legality of my pull request.

Also, I think pull request #49 should be closed.