### PR TITLE
Add a new "Locale" extension to access the \Locale PHP class

### DIFF
--- a/doc/locale.rst
+++ b/doc/locale.rst
@@ -1,0 +1,31 @@
+The Locale Extension
+====================
+
+The *Locale* extensions provides access to the `Locale PHP class`_. It currently
+features only the ``locale_primary_language`` function.
+
+Installation
+------------
+
+First, :ref:`install the Extensions library<extensions-install>`. Next, add
+the extension to Twig::
+
+    $twig->addExtension(new Twig_Extensions_Extension_Locale());
+
+``locale_primary_language``
+---------------------------
+
+Use the ``locale_primary_language`` function to get the primary language for the
+current or a given locale.
+
+.. code-block:: jinja
+
+    <meta http-equiv="Language" content="{{ locale_primary_language() }}" />
+
+Arguments
+~~~~~~~~~
+
+* ``locale``: The locale to obtain the primary language for. If ``NULL`` is given,
+  the default (current) locale will be retrieved from ``Locale::getDefault()``.
+
+.. _`Locale PHP class`:                      http://php.net/Locale

--- a/lib/Twig/Extensions/Extension/Locale.php
+++ b/lib/Twig/Extensions/Extension/Locale.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * This extension provides access to static methods from the \Locale class.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+class Twig_Extensions_Extension_Locale extends Twig_Extension
+{
+    public function getFunctions()
+    {
+        return array(
+            new Twig_SimpleFunction('locale_primary_language', 'twig_locale_primary_language'),
+        );
+    }
+}
+
+function twig_locale_primary_language($locale = null)
+{
+    $locale = $locale !== null ? $locale : Locale::getDefault();
+
+    return Locale::getPrimaryLanguage($locale);
+}
+

--- a/lib/Twig/Extensions/Extension/Locale.php
+++ b/lib/Twig/Extensions/Extension/Locale.php
@@ -32,7 +32,7 @@ class Twig_Extensions_Extension_Locale extends Twig_Extension
 
 function twig_locale_primary_language($locale = null)
 {
-    $locale = $locale !== null ? $locale : Locale::getDefault();
+    $locale = $locale == null ? Locale::getDefault() : $locale;
 
     return Locale::getPrimaryLanguage($locale);
 }

--- a/lib/Twig/Extensions/Extension/Locale.php
+++ b/lib/Twig/Extensions/Extension/Locale.php
@@ -29,4 +29,3 @@ function twig_locale_primary_language($locale = null)
 
     return Locale::getPrimaryLanguage($locale);
 }
-

--- a/lib/Twig/Extensions/Extension/Locale.php
+++ b/lib/Twig/Extensions/Extension/Locale.php
@@ -15,6 +15,13 @@
  */
 class Twig_Extensions_Extension_Locale extends Twig_Extension
 {
+    public function __construct()
+    {
+        if (!class_exists('Locale')) {
+            throw new RuntimeException('The PHP intl extension or the symfony/intl replacement layer needed to use the locale extension.');
+        }
+    }
+
     public function getFunctions()
     {
         return array(


### PR DESCRIPTION
Currently this only features a new `locale_primary_language` function to get the language for the current or a given locale.
