### PR TITLE
Add namespaced aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "symfony/translation": "Allow the time_diff output to be translated"
     },
     "autoload": {
-        "psr-0": { "Twig_Extensions_": "lib/" }
+        "psr-0": { "Twig_Extensions_": "lib/" },
+        "psr-4": { "Twig\\Extensions\\": "src/" }
     },
     "extra": {
         "branch-alias": {

--- a/lib/Twig/Extensions/Autoloader.php
+++ b/lib/Twig/Extensions/Autoloader.php
@@ -9,10 +9,14 @@
  * file that was distributed with this source code.
  */
 
+@trigger_error('The "Twig_Extensions_Autoloader" class is deprecated since version 1.5. Use Composer instead.', E_USER_DEPRECATED);
+
 /**
  * Autoloads Twig Extensions classes.
  *
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * @deprecated since version 1.5, use Composer instead.
  */
 class Twig_Extensions_Autoloader
 {

--- a/lib/Twig/Extensions/Extension/Array.php
+++ b/lib/Twig/Extensions/Extension/Array.php
@@ -7,7 +7,9 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
+ */
+
+/**
  * @author Ricard Clau <ricard.clau@gmail.com>
  */
 class Twig_Extensions_Extension_Array extends Twig_Extension
@@ -50,3 +52,5 @@ function twig_shuffle_filter($array)
 
     return $array;
 }
+
+class_alias('Twig_Extensions_Extension_Array', 'Twig\Extensions\ArrayExtension', false);

--- a/lib/Twig/Extensions/Extension/Date.php
+++ b/lib/Twig/Extensions/Extension/Date.php
@@ -97,3 +97,5 @@ class Twig_Extensions_Extension_Date extends Twig_Extension
         return 'date';
     }
 }
+
+class_alias('Twig_Extensions_Extension_Date', 'Twig\Extensions\DateExtension', false);

--- a/lib/Twig/Extensions/Extension/I18n.php
+++ b/lib/Twig/Extensions/Extension/I18n.php
@@ -37,3 +37,5 @@ class Twig_Extensions_Extension_I18n extends Twig_Extension
         return 'i18n';
     }
 }
+
+class_alias('Twig_Extensions_Extension_I18n', 'Twig\Extensions\I18nExtension', false);

--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -129,3 +129,5 @@ function twig_get_number_formatter($locale, $style)
 
     return $formatter;
 }
+
+class_alias('Twig_Extensions_Extension_Intl', 'Twig\Extensions\IntlExtension', false);

--- a/lib/Twig/Extensions/Extension/Text.php
+++ b/lib/Twig/Extensions/Extension/Text.php
@@ -95,3 +95,5 @@ if (function_exists('mb_get_info')) {
         return wordwrap($value, $length, $separator, !$preserve);
     }
 }
+
+class_alias('Twig_Extensions_Extension_Text', 'Twig\Extensions\TextExtension', false);

--- a/lib/Twig/Extensions/Node/Trans.php
+++ b/lib/Twig/Extensions/Node/Trans.php
@@ -162,3 +162,5 @@ class Twig_Extensions_Node_Trans extends Twig_Node
         return $plural ? 'ngettext' : 'gettext';
     }
 }
+
+class_alias('Twig_Extensions_Node_Trans', 'Twig\Extensions\Node\TransNode', false);

--- a/lib/Twig/Extensions/TokenParser/Trans.php
+++ b/lib/Twig/Extensions/TokenParser/Trans.php
@@ -84,3 +84,5 @@ class Twig_Extensions_TokenParser_Trans extends Twig_TokenParser
         }
     }
 }
+
+class_alias('Twig_Extensions_TokenParser_Trans', 'Twig\Extensions\TokenParser\TransTokenParser', false);

--- a/src/ArrayExtension.php
+++ b/src/ArrayExtension.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Extensions;
+
+require __DIR__.'/../lib/Twig/Extensions/Extension/Array.php';
+
+if (\false) {
+    class ArrayExtension extends \Twig_Extensions_Extension_Array
+    {
+    }
+}

--- a/src/DateExtension.php
+++ b/src/DateExtension.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Extensions;
+
+require __DIR__.'/../lib/Twig/Extensions/Extension/Date.php';
+
+if (\false) {
+    class DateExtension extends \Twig_Extensions_Extension_Date
+    {
+    }
+}

--- a/src/I18nExtension.php
+++ b/src/I18nExtension.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Extensions;
+
+require __DIR__.'/../lib/Twig/Extensions/Extension/I18n.php';
+
+if (\false) {
+    class I18nExtension extends \Twig_Extensions_Extension_I18n
+    {
+    }
+}

--- a/src/IntlExtension.php
+++ b/src/IntlExtension.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Extensions;
+
+require __DIR__.'/../lib/Twig/Extensions/Extension/Intl.php';
+
+if (\false) {
+    class IntlExtension extends \Twig_Extensions_Extension_Intl
+    {
+    }
+}

--- a/src/Node/TransNode.php
+++ b/src/Node/TransNode.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Extensions\Node;
+
+require __DIR__.'/../../lib/Twig/Extensions/Node/Trans.php';
+
+if (\false) {
+    class TransNode extends \Twig_Extensions_Node_Trans
+    {
+    }
+}

--- a/src/TextExtension.php
+++ b/src/TextExtension.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Extensions;
+
+require __DIR__.'/../lib/Twig/Extensions/Extension/Text.php';
+
+if (\false) {
+    class TextExtension extends \Twig_Extensions_Extension_Text
+    {
+    }
+}

--- a/src/TokenParser/TransTokenParser.php
+++ b/src/TokenParser/TransTokenParser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Extensions\TokenParser;
+
+require __DIR__.'/../../lib/Twig/Extensions/TokenParser/Trans.php';
+
+if (\false) {
+    class TransTokenParser extends \Twig_Extensions_TokenParser_Trans
+    {
+    }
+}


### PR DESCRIPTION
This is a first step towards moving this lib to namespaces.
It should fix https://github.com/symfony/symfony/issues/22849
If it works well, the same strategy could be applied to Twig.
I think adding runtime notices would make things more complex and is not needed.