### PR TITLE
Update gettext instructions for Poedit 2

### DIFF
--- a/doc/i18n.rst
+++ b/doc/i18n.rst
@@ -135,10 +135,21 @@ Extracting Template Strings
 ---------------------------
 
 If you use the Twig I18n extension, you will probably need to extract the
-template strings at some point. Unfortunately, the ``xgettext`` utility does
-not understand Twig templates natively. But there is a simple workaround: as
-Twig converts templates to PHP files, you can use ``xgettext`` on the template
-cache instead.
+template strings at some point.
+
+Using Poedit 2
+~~~~~~~~~~~~~~
+
+Poedit 2 has native support for extracting from Twig files and no extra
+setup is necessary (Pro version).
+
+Using ``xgettext`` or Poedit 1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unfortunately, the ``xgettext`` utility does not understand Twig templates
+natively and neither do tools based on it such as free versions of Poedit.
+But there is a simple workaround: as Twig converts templates to
+PHP files, you can use ``xgettext`` on the template cache instead.
 
 Create a script that forces the generation of the cache for all your
 templates. Here is a simple example to get you started::


### PR DESCRIPTION
This PR updates i18n documentation to mention Poedit 2's ability to extract from Twig templates directly. `xgettext` instructions for using the cache or Twig Gettext Extractor are left intact for those that prefer that approach.