### PR TITLE
Add a feature to handle digits parts on a currency

### DIFF
--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -82,10 +82,14 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
     return $formatter->format($number, $typeValues[$type]);
 }
 
-function twig_localized_currency_filter($number, $currency = null, $locale = null)
+function twig_localized_currency_filter($number, $currency = null, $locale = null, $digits = true)
 {
     $formatter = twig_get_number_formatter($locale, 'currency');
 
+    if (!$digits) {
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+    }
+    
     return $formatter->formatCurrency($number, $currency);
 }
 

--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -82,14 +82,12 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
     return $formatter->format($number, $typeValues[$type]);
 }
 
-function twig_localized_currency_filter($number, $currency = null, $locale = null, $digits = true)
+function twig_localized_currency_filter($number, $currency = null, $digits = 2, $locale = null)
 {
     $formatter = twig_get_number_formatter($locale, 'currency');
 
-    if (!$digits) {
-        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
-    }
-    
+    $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $digits);
+
     return $formatter->formatCurrency($number, $currency);
 }
 
@@ -105,7 +103,7 @@ function twig_get_number_formatter($locale, $style)
 {
     static $formatter, $currentStyle;
 
-    $locale = $locale !== null ? $locale : Locale::getDefault();
+    $locale = null !== $locale ? $locale : Locale::getDefault();
 
     if ($formatter && $formatter->getLocale() === $locale && $currentStyle === $style) {
         // Return same instance of NumberFormatter if parameters are the same


### PR DESCRIPTION
Everytime, each digits parts is here, and I want to choose if I keep it or not.

Example; 

`{{ 10000 | localizedcurrency('SWF`) }} `

for Swiss peaple become 

`SWF 10'000.00.`

No digits needed for me so I use like : 

`{{ 10000 | localizedcurrency('SWF', 0)}} `

 for Swiss people become 

`SWF 10'000`