### PR TITLE
fix typo

### DIFF
--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -90,7 +90,7 @@ representating the number.
 Arguments
 ~~~~~~~~~
 
-* ``style``: Optional date format (default: 'decimal'). Choose one of these formats:
+* ``style``: Optional number format (default: 'decimal'). Choose one of these formats:
 
   * 'decimal':    `NumberFormatter::DECIMAL`_
   * 'currency':   `NumberFormatter::CURRENCY`_


### PR DESCRIPTION
fixes a typo, probably due to a copy & paste of the previous section