### PR TITLE
Add package_version and pretty_package_version Twig functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 
 env:
     - DEPS=no
+    - INSTALL_PACKAGE_VERSIONS=no
 
 before_install:
     - phpenv config-rm xdebug.ini
@@ -16,6 +17,7 @@ before_install:
 before_script:
     - if [ "$DEPS" == "low" ]; then composer --prefer-lowest --prefer-stable update; fi;
     - if [ "$DEPS" == "no" ]; then composer install; fi;
+    - if [ "$INSTALL_PACKAGE_VERSIONS" == "yes" ]; then composer require --dev ocramius/package-versions jean85/pretty-package-versions; fi;
 
 script: |
     ./vendor/bin/simple-phpunit
@@ -29,6 +31,9 @@ matrix:
         - php: 5.6
           env: DEPS=low
         - php: 7.0
+          env: INSTALL_PACKAGE_VERSIONS=yes
         - php: 7.1
+          env: INSTALL_PACKAGE_VERSIONS=yes
         - php: 7.2
+          env: INSTALL_PACKAGE_VERSIONS=yes
     fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
         "symfony/translation": "^2.7|^3.4"
     },
     "suggest": {
-        "symfony/translation": "Allow the time_diff output to be translated"
+        "symfony/translation": "Allow the time_diff output to be translated",
+        "ocramius/package-versions": "Allows using package_version Twig function",
+        "jean85/pretty-package-versions": "Allows using pretty_package_version Twig function"
     },
     "autoload": {
         "psr-0": { "Twig_Extensions_": "lib/" },

--- a/lib/Twig/Extensions/Extension/Version.php
+++ b/lib/Twig/Extensions/Extension/Version.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of Twig.
+ *
+ * (c) 2009 Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use Jean85\PrettyVersions;
+use PackageVersions\Versions;
+
+/**
+ * @author Edi Modrić <edi.modric@gmail.com>
+ */
+class Twig_Extensions_Extension_Version extends Twig_Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            new Twig_SimpleFilter('package_version', 'twig_package_version'),
+            new Twig_SimpleFilter('pretty_package_version', 'twig_pretty_package_version'),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'Version';
+    }
+}
+
+function twig_package_version($value)
+{
+    if (!class_exists('PackageVersions\Versions')) {
+        throw new RuntimeException('ocramius/package-versions library is needed to use package_version Twig function.');
+    }
+
+    return Versions::getVersion($value);
+}
+
+function twig_pretty_package_version($value)
+{
+    if (!class_exists('Jean85\PrettyVersions')) {
+        throw new RuntimeException('jean85/pretty-package-versions library is needed to use pretty_package_version Twig function.');
+    }
+
+    return PrettyVersions::getVersion($value);
+}
+
+class_alias('Twig_Extensions_Extension_Version', 'Twig\Extensions\VersionExtension', false);

--- a/src/VersionExtension.php
+++ b/src/VersionExtension.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Extensions;
+
+class_exists('Twig_Extensions_Extension_Version');
+
+if (\false) {
+    class VersionExtension extends \Twig_Extensions_Extension_Version
+    {
+    }
+}

--- a/test/Twig/Tests/Extension/VersionTest.php
+++ b/test/Twig/Tests/Extension/VersionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Twig.
+ *
+ * (c) Fabien Potencier
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once __DIR__.'/../../../../lib/Twig/Extensions/Extension/Version.php';
+
+class Twig_Tests_Extension_VersionTest extends \PHPUnit\Framework\TestCase
+{
+    public function setUp()
+    {
+        if (PHP_VERSION_ID < 70000) {
+            $this->markTestSkipped('Version extension tests require PHP 7.0 and later.');
+        }
+    }
+
+    public function testPackageVersion()
+    {
+        $output = twig_package_version('twig/twig');
+        $this->assertInternalType('string', $output);
+        $this->assertNotEmpty($output);
+    }
+
+    public function testPrettyPackageVersion()
+    {
+        $output = twig_pretty_package_version('twig/twig');
+        $this->assertInstanceOf('Jean85\Version', $output);
+    }
+}


### PR DESCRIPTION
Hi!

This adds two new functions `package_version` and `pretty_package_version`, which use `ocramius/package-versions` and `jean85/pretty-package-versions` libraries, respectivelly, to provide versions to Twig templates.

In PHP 5 era, most libraries had a `Version` class, which included constants that specify the current version. Those constants were easy to use inside Twig templates to display a version somewhere in the UI. However, with PHP 7, more and more libraries migrate to `ocramius/package-versions`, which means that we cannot simply display a version of a product or a library somewhere in the interface.

I felt that these two Twig functions might be interesting to wider audiences, hence the PR.

If you feel that this might be useful, I can then work on docs too.