### PR TITLE
Ignore the IdentityTranslator so that the texts are translated properly

### DIFF
--- a/lib/Twig/Extensions/Extension/Date.php
+++ b/lib/Twig/Extensions/Extension/Date.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\IdentityTranslator;
 
 /**
  * @author Robin van der Vleuten <robinvdvleuten@gmail.com>
@@ -31,6 +32,11 @@ class Twig_Extensions_Extension_Date extends Twig_Extension
 
     public function __construct(TranslatorInterface $translator = null)
     {
+        // Ignore the IdentityTranslator, otherwise the parameters won't be replaced properly
+        if ($translator instanceof IdentityTranslator) {
+            $translator = null;
+        }
+
         $this->translator = $translator;
     }
 


### PR DESCRIPTION
Since we've introduced the identity translator in Symfony, the `time_diff` does not work anymore. This ignores it and consider the translator as not useful (so it actually displays the diffs properly 💃)