### PR TITLE
Cache IntlDateFormatter for speed

### DIFF
--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -27,7 +27,11 @@ by the `strtotime`_ function), `DateTime`_ instances, or `Unix timestamps`_.
 .. note::
 
     Internally, Twig uses the PHP `IntlDateFormatter::create()`_ function for
-    the date.
+    the date. These formatters are cached for performance, but only first 5.
+    If you want to use more formatters many times on the same environment,
+    you should increase ``maxDateFormattersCached`` property::
+
+    $twig->getExtension(Twig_Extensions_Extension_Intl::class)->maxDateFormattersCached = 32
 
 Arguments
 ~~~~~~~~~

--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -11,6 +11,8 @@
 
 class Twig_Extensions_Extension_Intl extends Twig_Extension
 {
+    public $maxDateFormattersCached = 5;
+
     public function __construct()
     {
         if (!class_exists('IntlDateFormatter')) {
@@ -42,6 +44,7 @@ class Twig_Extensions_Extension_Intl extends Twig_Extension
 function twig_localized_date_filter(Twig_Environment $env, $date, $dateFormat = 'medium', $timeFormat = 'medium', $locale = null, $timezone = null, $format = null, $calendar = 'gregorian')
 {
     static $formattersCache;
+    static $cacheFull = false;
 
     $date = twig_date_converter($env, $date, $timezone);
 
@@ -71,7 +74,11 @@ function twig_localized_date_filter(Twig_Environment $env, $date, $dateFormat = 
             $formatterParams[3] = IntlTimeZone::createTimeZone($date->getTimezone()->getName());
         }
         $formatter = call_user_func_array([IntlDateFormatter::class, 'create'], $formatterParams);
-        $formattersCache[$hashedFormat] = $formatter;
+        if (!$cacheFull && count($formattersCache) < $env->getExtension(Twig_Extensions_Extension_Intl::class)->maxDateFormattersCached) {
+            $formattersCache[$hashedFormat] = $formatter;
+        } else {
+            $cacheFull = true;
+        }
     }
 
     return $formatter->format($date->getTimestamp());


### PR DESCRIPTION
We have noticed that instantiating of IntlDateFormatter takes more than half time of entire template rendering. So there is a little cache, improving performance almost twice.

P. S. There is failing test (`testLocalizedDateFilterWithDateTimeZone`), but it was already broken.