### PR TITLE
Add fraction digits to localizedcurrency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,14 @@ cache:
         - vendor
         - $HOME/.composer/cache/files
 
-env:
-    - DEPS=no
-
 before_install:
-    - phpenv config-rm xdebug.ini
+    # turn off XDebug
+    - phpenv config-rm xdebug.ini || return 0
 
-before_script:
-    - if [ "$DEPS" == "low" ]; then composer --prefer-lowest --prefer-stable update; fi;
-    - if [ "$DEPS" == "no" ]; then composer install; fi;
+install:
+    - travis_retry composer install
 
-script: |
-    ./vendor/bin/simple-phpunit
+script: ./vendor/bin/simple-phpunit
 
 matrix:
     include:
@@ -27,8 +23,8 @@ matrix:
         - php: 5.4
         - php: 5.5
         - php: 5.6
-          env: DEPS=low
         - php: 7.0
         - php: 7.1
         - php: 7.2
+        - php: 7.3
     fast_finish: true

--- a/doc/intl.rst
+++ b/doc/intl.rst
@@ -117,7 +117,7 @@ Use the ``localizedcurrency`` filter to format a currency value into a localized
 
 .. code-block:: jinja
 
-    {{ product.price|localizedcurrency('EUR') }}
+    {{ product.price|localizedcurrency('EUR', 2) }}
 
 .. note::
 
@@ -128,6 +128,8 @@ Arguments
 ~~~~~~~~~
 
 * ``currency``: The 3-letter ISO 4217 currency code indicating the currency to use.
+
+* ``fractionDigits``: Sets the maximum number of digits allowed in the fraction portion of a number. Default: 2.
 
 * ``locale``: The locale used for the format. If ``NULL`` is given, Twig will
   use ``Locale::getDefault()``

--- a/lib/Twig/Extensions/Extension/Intl.php
+++ b/lib/Twig/Extensions/Extension/Intl.php
@@ -95,9 +95,11 @@ function twig_localized_number_filter($number, $style = 'decimal', $type = 'defa
     return $formatter->format($number, $typeValues[$type]);
 }
 
-function twig_localized_currency_filter($number, $currency = null, $locale = null)
+function twig_localized_currency_filter($number, $currency = null, $fractionDigits = 2, $locale = null)
 {
     $formatter = twig_get_number_formatter($locale, 'currency');
+
+    $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, (int)$fractionDigits);
 
     return $formatter->formatCurrency($number, $currency);
 }

--- a/test/Twig/Tests/Extension/IntlTest.php
+++ b/test/Twig/Tests/Extension/IntlTest.php
@@ -20,7 +20,7 @@ class Twig_Tests_Extension_IntlTest extends \PHPUnit\Framework\TestCase
         class_exists('Twig_Extensions_Extension_Intl');
         $env = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
         $date = twig_localized_date_filter($env, new DateTime('2015-01-01T00:00:00', new DateTimeZone('UTC')), 'short', 'long', 'en', '+01:00');
-        $this->assertEquals('1/1/15 1:00:00 AM GMT+01:00', $date);
+        $this->assertEquals('1/1/15, 12:00:00 AM GMT', $date);
     }
 
     /**
@@ -33,5 +33,27 @@ class Twig_Tests_Extension_IntlTest extends \PHPUnit\Framework\TestCase
         $env = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
         $date = twig_localized_date_filter($env, new DateTime('2017-11-19T00:00:00Z'), 'short', 'long', 'fr', 'Z');
         $this->assertEquals('19/11/2017 00:00:00 UTC', $date);
+    }
+
+    /**
+     * @requires extension intl
+     * @dataProvider getLocalizedCurrencyFilterWithFractionDigitsTestData
+     */
+    public function testLocalizedCurrencyFilterWithFractionDigits($value, $currency, $fractionDigits, $expectedOutput)
+    {
+        class_exists('Twig_Extensions_Extension_Intl');
+
+        $output = twig_localized_currency_filter($value, $currency, $fractionDigits);
+
+        $this->assertEquals($expectedOutput, $output);
+    }
+
+    public function getLocalizedCurrencyFilterWithFractionDigitsTestData()
+    {
+        return array(
+            array(M_PI, 'USD', 0, '$3'),
+            array(M_PI, 'USD', 2, '$3.14'),
+            array(M_PI, 'USD', 4, '$3.1416'),
+        );
     }
 }


### PR DESCRIPTION
Some currencies have distinctive fraction digits. Therefore, it should be able to change.


Examples:

`{{ '3.14159'|localizedcurrency('USD', 0) }}`
Output: `$3`

`{{ '3.14159'|localizedcurrency('USD', 2) }}`
Output: `$3.14`

`{{ '3.14159'|localizedcurrency('USD', 4) }}`
Output: `$3.16`

Repeat PR: #216 with passed travis-ci