### PR TITLE
Add caution to the i18n doc about embedded vars not being autoescaped

### DIFF
--- a/doc/i18n.rst
+++ b/doc/i18n.rst
@@ -73,6 +73,22 @@ result to a variable:
         Hello {{ name }}!
     {% endtrans %}
 
+.. caution::
+
+    The embedded values are not automatically escaped. You need to escape them
+    yourself using the `|e` filter:
+
+.. code-block:: jinja
+
+    {% set unsafe_var = "<script>alert('Hello from XSS')</script>" %}
+    {% set safe_var = unsafe_var|e %}
+
+    {% trans %}
+        Not escaped: {{ unsafe_var }}
+
+        Escaped: {{ safe_var }}
+    {% endtrans %}
+
 To pluralize a translatable string, use the ``plural`` block:
 
 .. code-block:: jinja


### PR DESCRIPTION
This relates to #241: variables embedded in `{% trans %}` tags are not subject to automatic escaping.

I believe Twig users will reasonably expect to be safe by default, unless they opt out of it using `|raw`.

I found out about this behavior after penetration testing was performed on an application I work on. I worry others may find out the hard way.