### PR TITLE
Allow Twig 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "twig/twig": "^2.10",
+        "twig/twig": "^2.10 || ^3.0",
         "symfony/polyfill-mbstring": "^1.10"
     },
     "require-dev": {


### PR DESCRIPTION
I realize that this repository is abandoned, but it would help if it supported Twig 3.0 so we can use it in situations where it is not possible yet to use twig-intl due it not supporting Symfony 3.4.