### PR TITLE
Make DateExtension compatible with the new TranslatorInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
 
 before_script:
     - if [ "$DEPS" == "low" ]; then composer --prefer-lowest --prefer-stable update; fi;
+    - if [ "$DEPS" == "4.x" ]; then composer require --dev symfony/translation:"^4.2"; fi
     - if [ "$DEPS" == "no" ]; then composer install; fi;
 
 script: |
@@ -24,5 +25,7 @@ matrix:
     include:
         - php: 7.1
           env: DEPS=low
+        - php: 7.1
+          env: DEPS=4.x
         - php: 7.2
     fast_finish: true

--- a/src/DateExtension.php
+++ b/src/DateExtension.php
@@ -36,7 +36,7 @@ class DateExtension extends AbstractExtension
 
     public function __construct($translator = null)
     {
-        if (!$translator instanceof LegacyTranslatorInterface && !$translator instanceof TranslatorInterface) {
+        if (null !== $translator && !$translator instanceof LegacyTranslatorInterface && !$translator instanceof TranslatorInterface) {
             throw new \TypeError(sprintf('Argument 1 passed to %s() must be an instance of %s, %s given.', __METHOD__, TranslatorInterface::class, \is_object($translator) ? \get_class($translator) : \gettype($translator)));
         }
 

--- a/src/DateExtension.php
+++ b/src/DateExtension.php
@@ -37,7 +37,7 @@ class DateExtension extends AbstractExtension
     public function __construct($translator = null)
     {
         if (null !== $translator && !$translator instanceof LegacyTranslatorInterface && !$translator instanceof TranslatorInterface) {
-            throw new \TypeError(sprintf('Argument 1 passed to %s() must be an instance of %s, %s given.', __METHOD__, TranslatorInterface::class, \is_object($translator) ? \get_class($translator) : \gettype($translator)));
+            throw new \TypeError(sprintf('Argument 1 passed to %s() must be an instance of %s or null, %s given.', __METHOD__, TranslatorInterface::class, \is_object($translator) ? \get_class($translator) : \gettype($translator)));
         }
 
         // Ignore the IdentityTranslator, otherwise the parameters won't be replaced properly

--- a/test/DateExtensionTest.php
+++ b/test/DateExtensionTest.php
@@ -12,7 +12,8 @@
 namespace Twig\Tests\Extension;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Extensions\DateExtension;
 use Twig\Loader\LoaderInterface;
@@ -67,7 +68,7 @@ class DateExtensionTest extends TestCase
         $translator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
         $translator
             ->expects($this->once())
-            ->method('transChoice')
+            ->method('trans')
             ->with($translated);
 
         $extension = new DateExtension($translator);

--- a/test/DateExtensionTest.php
+++ b/test/DateExtensionTest.php
@@ -24,7 +24,7 @@ class DateExtensionTest extends TestCase
 {
     private $env;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->env = new Environment($this->getMockBuilder(LoaderInterface::class)->getMock());
     }

--- a/test/DateExtensionTest.php
+++ b/test/DateExtensionTest.php
@@ -65,14 +65,39 @@ class DateExtensionTest extends TestCase
      */
     public function testDiffCanReturnTranslatableString($expected, $translated, $date, $now)
     {
+        if (!interface_exists(TranslatorInterface::class)) {
+            $this->markTestSkipped(sprintf('Interface "%s" does not exist', TranslatorInterface::class));
+        }
+
         $translator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
         $translator
             ->expects($this->once())
             ->method('trans')
-            ->with($translated);
+            ->with($translated)
+            ->willReturn($expected);
 
         $extension = new DateExtension($translator);
-        $extension->diff($this->env, $date, $now);
+        $this->assertSame($expected, $extension->diff($this->env, $date, $now));
+    }
+
+    /**
+     * @dataProvider getDiffTestData()
+     */
+    public function testDiffCanReturnTranslatableStringLegacy($expected, $translated, $date, $now)
+    {
+        if (!interface_exists(LegacyTranslatorInterface::class)) {
+            $this->markTestSkipped(sprintf('Interface "%s" does not exist', LegacyTranslatorInterface::class));
+        }
+
+        $translator = $this->getMockBuilder(LegacyTranslatorInterface::class)->getMock();
+        $translator
+            ->expects($this->once())
+            ->method('transChoice')
+            ->with($translated)
+            ->willReturn($expected);
+
+        $extension = new DateExtension($translator);
+        $this->assertSame($expected, $extension->diff($this->env, $date, $now));
     }
 
     public function getDiffTestData()

--- a/test/TextExtensionTest.php
+++ b/test/TextExtensionTest.php
@@ -20,7 +20,7 @@ class TextExtensionTest extends \PHPUnit\Framework\TestCase
 {
     private $env;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->env = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
         $this->env


### PR DESCRIPTION
Fixes deprecation error

> The "Symfony\Component\Translation\LoggingTranslator::transChoice"  method is deprecated since Symfony 4.2, use the trans() one instead with a "%count%" parameter.